### PR TITLE
feat: integrate payment gateways

### DIFF
--- a/client/src/pages/checkout.tsx
+++ b/client/src/pages/checkout.tsx
@@ -183,7 +183,7 @@ export default function Checkout() {
     setCurrentStep(currentStep - 1);
   };
 
-  const handlePlaceOrder = () => {
+  const handlePlaceOrder = async () => {
     if (!validateStep(currentStep)) {
       toast({
         title: "Informations manquantes",
@@ -204,11 +204,35 @@ export default function Checkout() {
       shippingAddress,
       billingAddress: sameAsBilling ? shippingAddress : billingAddress,
       paymentMethod,
-      paymentStatus: paymentMethod === "cod" ? "pending" : "paid",
       notes: "",
     };
 
-    createOrderMutation.mutate(orderData);
+    if (paymentMethod === "cod") {
+      createOrderMutation.mutate(orderData);
+      return;
+    }
+
+    try {
+      const orderRes = await apiRequest("POST", "/api/orders", orderData);
+      const order = await orderRes.json();
+      const payRes = await apiRequest(
+        "POST",
+        `/api/payments/${paymentMethod}`,
+        {
+          amount: Math.round(total * 100),
+          note: order.orderNumber,
+          returnUrl: `${window.location.origin}/orders/${order.id}`,
+        },
+      );
+      const payment = await payRes.json();
+      window.location.href = payment.url;
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: "Impossible de procéder au paiement.",
+        variant: "destructive",
+      });
+    }
   };
 
   const steps = [
@@ -385,28 +409,23 @@ export default function Checkout() {
                       <Label htmlFor="cod">Paiement à la livraison</Label>
                     </div>
                     <div className="flex items-center space-x-2">
-                      <RadioGroupItem value="card" id="card" data-testid="payment-card" />
-                      <Label htmlFor="card">Carte bancaire</Label>
+                      <RadioGroupItem value="paymee" id="paymee" data-testid="payment-paymee" />
+                      <Label htmlFor="paymee">Paymee</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem value="flouci" id="flouci" data-testid="payment-flouci" />
+                      <Label htmlFor="flouci">Flouci</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem value="stripe" id="stripe" data-testid="payment-stripe" />
+                      <Label htmlFor="stripe">Carte (Stripe)</Label>
                     </div>
                   </RadioGroup>
 
-                  {paymentMethod === "card" && (
-                    <div className="mt-6 space-y-4">
-                      <div>
-                        <Label htmlFor="cardNumber">Numéro de carte</Label>
-                        <Input id="cardNumber" placeholder="1234 5678 9012 3456" data-testid="card-number" />
-                      </div>
-                      <div className="grid grid-cols-2 gap-4">
-                        <div>
-                          <Label htmlFor="expiry">Date d'expiration</Label>
-                          <Input id="expiry" placeholder="MM/AA" data-testid="card-expiry" />
-                        </div>
-                        <div>
-                          <Label htmlFor="cvv">CVV</Label>
-                          <Input id="cvv" placeholder="123" data-testid="card-cvv" />
-                        </div>
-                      </div>
-                    </div>
+                  {paymentMethod !== "cod" && (
+                    <p className="mt-4 text-sm text-gray-600">
+                      Vous serez redirigé vers une page de paiement sécurisée.
+                    </p>
                   )}
 
                   <div className="mt-6">

--- a/server/payments.ts
+++ b/server/payments.ts
@@ -1,0 +1,107 @@
+import { Router } from "express";
+import Stripe from "stripe";
+
+// Initialize Stripe client when API key provided
+const stripe = process.env.STRIPE_SECRET_KEY
+  ? new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: "2024-09-30" as any })
+  : null;
+
+export const paymentRouter = Router();
+
+// Stripe checkout session
+paymentRouter.post("/stripe", async (req, res) => {
+  try {
+    if (!stripe) {
+      return res.status(500).json({ message: "Stripe non configuré" });
+    }
+    const { amount, currency = "usd", successUrl, cancelUrl } = req.body as {
+      amount: number; currency?: string; successUrl: string; cancelUrl: string;
+    };
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      payment_method_types: ["card"],
+      line_items: [
+        {
+          price_data: {
+            currency,
+            product_data: { name: "Order" },
+            unit_amount: amount,
+          },
+          quantity: 1,
+        },
+      ],
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+    });
+    res.json({ url: session.url });
+  } catch (err) {
+    console.error("Stripe checkout error", err);
+    res.status(500).json({ message: "Stripe checkout failed" });
+  }
+});
+
+// Paymee payment
+paymentRouter.post("/paymee", async (req, res) => {
+  try {
+    const { amount, note, returnUrl } = req.body as {
+      amount: number; note?: string; returnUrl: string;
+    };
+    const response = await fetch("https://sandbox.paymee.tn/api/v2/payments/init", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Token ${process.env.PAYMEE_API_KEY}`,
+      },
+      body: JSON.stringify({
+        amount,
+        note,
+        url: returnUrl,
+      }),
+    });
+    const data = await response.json();
+    const url = data?.data?.payment_url || data?.payment_url || data?.result?.link;
+    if (!url) {
+      return res.status(500).json({ message: "Paymee response invalide" });
+    }
+    res.json({ url });
+  } catch (err) {
+    console.error("Paymee error", err);
+    res.status(500).json({ message: "Paymee payment failed" });
+  }
+});
+
+// Flouci payment
+paymentRouter.post("/flouci", async (req, res) => {
+  try {
+    const { amount, description, returnUrl } = req.body as {
+      amount: number; description?: string; returnUrl: string;
+    };
+    const response = await fetch("https://api.flouci.com/api/generate_payment", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        store_id: process.env.FLOUCI_STORE_ID || "",
+        store_secret: process.env.FLOUCI_STORE_SECRET || "",
+      } as any,
+      body: JSON.stringify({
+        amount,
+        accept_card: true,
+        session_timeout_secs: 1200,
+        description,
+        success_link: returnUrl,
+        fail_link: returnUrl,
+      }),
+    });
+    const data = await response.json();
+    const url = data?.result?.link || data?.link;
+    if (!url) {
+      return res.status(500).json({ message: "Flouci response invalide" });
+    }
+    res.json({ url });
+  } catch (err) {
+    console.error("Flouci error", err);
+    res.status(500).json({ message: "Flouci payment failed" });
+  }
+});
+
+export default paymentRouter;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { setupAuth, isAuthenticated } from "./auth";
+import paymentRouter from "./payments";
 import { insertProductSchema, insertCategorySchema, insertOrderSchema, insertCartItemSchema, insertReviewSchema, insertNewsletterSchema } from "@shared/schema";
 import { z } from "zod";
 
@@ -30,6 +31,9 @@ app.get("/api/auth/user", (req, res) => {
   res.set("Cache-Control", "private, max-age=60");
   res.json({ user });
 });
+
+  // Payment routes
+  app.use("/api/payments", isAuthenticated, paymentRouter);
 
   // Newsletter subscription route
   app.post('/api/newsletter', async (req, res) => {


### PR DESCRIPTION
## Summary
- add payment API routes for Stripe, Paymee and Flouci
- mount payments router behind authentication
- support gateway selection and redirection in checkout

## Testing
- `npm test` (fails: Missing script `test`)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68960130e92483298a443886357d944b