### PR TITLE
feat: integrate konnect payment

### DIFF
--- a/client/src/pages/checkout.tsx
+++ b/client/src/pages/checkout.tsx
@@ -183,7 +183,7 @@ export default function Checkout() {
     setCurrentStep(currentStep - 1);
   };
 
-  const handlePlaceOrder = () => {
+  const handlePlaceOrder = async () => {
     if (!validateStep(currentStep)) {
       toast({
         title: "Informations manquantes",
@@ -204,11 +204,35 @@ export default function Checkout() {
       shippingAddress,
       billingAddress: sameAsBilling ? shippingAddress : billingAddress,
       paymentMethod,
-      paymentStatus: paymentMethod === "cod" ? "pending" : "paid",
       notes: "",
     };
 
-    createOrderMutation.mutate(orderData);
+    if (paymentMethod === "cod") {
+      createOrderMutation.mutate(orderData);
+      return;
+    }
+
+    try {
+      const orderRes = await apiRequest("POST", "/api/orders", orderData);
+      const order = await orderRes.json();
+      const payRes = await apiRequest(
+        "POST",
+        "/api/payments/konnect",
+        {
+          amount: Math.round(total * 100),
+          orderId: order.orderNumber,
+          returnUrl: `${window.location.origin}/orders/${order.id}`,
+        },
+      );
+      const payment = await payRes.json();
+      window.location.href = payment.url;
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: "Impossible de procéder au paiement.",
+        variant: "destructive",
+      });
+    }
   };
 
   const steps = [
@@ -385,28 +409,15 @@ export default function Checkout() {
                       <Label htmlFor="cod">Paiement à la livraison</Label>
                     </div>
                     <div className="flex items-center space-x-2">
-                      <RadioGroupItem value="card" id="card" data-testid="payment-card" />
-                      <Label htmlFor="card">Carte bancaire</Label>
+                      <RadioGroupItem value="konnect" id="konnect" data-testid="payment-konnect" />
+                      <Label htmlFor="konnect">Paiement en ligne (Konnect)</Label>
                     </div>
                   </RadioGroup>
 
-                  {paymentMethod === "card" && (
-                    <div className="mt-6 space-y-4">
-                      <div>
-                        <Label htmlFor="cardNumber">Numéro de carte</Label>
-                        <Input id="cardNumber" placeholder="1234 5678 9012 3456" data-testid="card-number" />
-                      </div>
-                      <div className="grid grid-cols-2 gap-4">
-                        <div>
-                          <Label htmlFor="expiry">Date d'expiration</Label>
-                          <Input id="expiry" placeholder="MM/AA" data-testid="card-expiry" />
-                        </div>
-                        <div>
-                          <Label htmlFor="cvv">CVV</Label>
-                          <Input id="cvv" placeholder="123" data-testid="card-cvv" />
-                        </div>
-                      </div>
-                    </div>
+                  {paymentMethod !== "cod" && (
+                    <p className="mt-4 text-sm text-gray-600">
+                      Vous serez redirigé vers une page de paiement sécurisée.
+                    </p>
                   )}
 
                   <div className="mt-6">
@@ -447,7 +458,7 @@ export default function Checkout() {
                     <div>
                       <h3 className="font-semibold mb-2">Méthode de paiement</h3>
                       <p className="text-sm text-gray-600" data-testid="payment-summary">
-                        {paymentMethod === "cod" ? "Paiement à la livraison" : "Carte bancaire"}
+                        {paymentMethod === "cod" ? "Paiement à la livraison" : "Paiement en ligne (Konnect)"}
                       </p>
                     </div>
 

--- a/server/payments.ts
+++ b/server/payments.ts
@@ -1,0 +1,39 @@
+import { Router } from "express";
+
+export const paymentRouter = Router();
+
+paymentRouter.post("/konnect", async (req, res) => {
+  try {
+    const { amount, orderId, returnUrl } = req.body as {
+      amount: number;
+      orderId: string;
+      returnUrl: string;
+    };
+
+    const response = await fetch("https://api.konnect.network/api/v2/payments/init", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Token ${process.env.KONNECT_API_KEY}`,
+      },
+      body: JSON.stringify({
+        amount,
+        note: orderId,
+        url: returnUrl,
+      }),
+    });
+
+    const data = await response.json();
+    const url = data?.payment_url || data?.redirect_url || data?.result?.link;
+    if (!url) {
+      return res.status(500).json({ message: "Konnect response invalide" });
+    }
+
+    res.json({ url });
+  } catch (err) {
+    console.error("Konnect error", err);
+    res.status(500).json({ message: "Konnect payment failed" });
+  }
+});
+
+export default paymentRouter;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { setupAuth, isAuthenticated } from "./auth";
+import paymentRouter from "./payments";
 import { insertProductSchema, insertCategorySchema, insertOrderSchema, insertCartItemSchema, insertReviewSchema, insertNewsletterSchema } from "@shared/schema";
 import { z } from "zod";
 
@@ -30,6 +31,9 @@ app.get("/api/auth/user", (req, res) => {
   res.set("Cache-Control", "private, max-age=60");
   res.json({ user });
 });
+
+  // Payment routes
+  app.use("/api/payments", isAuthenticated, paymentRouter);
 
   // Newsletter subscription route
   app.post('/api/newsletter', async (req, res) => {


### PR DESCRIPTION
## Summary
- replace Stripe/Paymee/Flouci endpoints with Konnect payment session
- update checkout flow to redirect through Konnect for online payments

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68960130e92483298a443886357d944b