### PR TITLE
Add missing page links to footer

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,22 @@ import ProductDetail from "@/pages/product-detail";
 import Cart from "@/pages/cart";
 import Checkout from "@/pages/checkout";
 import About from "@/pages/about";
+import Boutiques from "@/pages/boutiques";
+import FAQ from "@/pages/faq";
+import Contact from "@/pages/contact";
+import Livraison from "@/pages/livraison";
+import Retours from "@/pages/retours";
+import ManteauxTrenchs from "@/pages/manteaux-trenchs";
+import Robes from "@/pages/robes";
+import Chemises from "@/pages/chemises";
+import Jupes from "@/pages/jupes";
+import ShortsPage from "@/pages/shorts";
+import Combinaisons from "@/pages/combinaisons";
+import CGV from "@/pages/cgv";
+import MentionsLegales from "@/pages/mentions-legales";
+import DonneesPersonnelles from "@/pages/donnees-personnelles";
+import NousRejoindre from "@/pages/nous-rejoindre";
+import LaMarque from "@/pages/la-marque";
 import Wishlist from "@/pages/wishlist";
 import AdminDashboard from "@/pages/admin/dashboard";
 import AdminProducts from "@/pages/admin/products";
@@ -46,6 +62,22 @@ function Router() {
       <Route path="/checkout" component={Checkout} />
       <Route path="/wishlist" component={Wishlist} />
       <Route path="/about" component={About} />
+      <Route path="/boutiques" component={Boutiques} />
+      <Route path="/faq" component={FAQ} />
+      <Route path="/contact" component={Contact} />
+      <Route path="/livraison" component={Livraison} />
+      <Route path="/retours" component={Retours} />
+      <Route path="/manteaux-trenchs" component={ManteauxTrenchs} />
+      <Route path="/robes" component={Robes} />
+      <Route path="/chemises" component={Chemises} />
+      <Route path="/jupes" component={Jupes} />
+      <Route path="/shorts" component={ShortsPage} />
+      <Route path="/combinaisons" component={Combinaisons} />
+      <Route path="/cgv" component={CGV} />
+      <Route path="/mentions-legales" component={MentionsLegales} />
+      <Route path="/donnees-personnelles" component={DonneesPersonnelles} />
+      <Route path="/nous-rejoindre" component={NousRejoindre} />
+      <Route path="/la-marque" component={LaMarque} />
 
       {isAuthenticated && (
         <>

--- a/client/src/components/layout/footer.tsx
+++ b/client/src/components/layout/footer.tsx
@@ -76,46 +76,60 @@ export function Footer() {
       </div>
 
       {/* Navigation Links */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-6 px-6 py-10 text-gray-800">
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-6 px-6 py-10 text-gray-800">
         <div>
           <h3 className="font-bold mb-2">SERVICES</h3>
           <ul className="space-y-1">
-            <li><a href="#">Nos boutiques</a></li>
+            <li><a href="/boutiques">Nos boutiques</a></li>
             <li><a href="/faq">FAQ</a></li>
-            <li><a href="#">Contact</a></li>
-            <li><a href="#">Livraison</a></li>
-            <li><a href="#">Retours</a></li>
+            <li><a href="/contact">Contact</a></li>
+            <li><a href="/livraison">Livraison</a></li>
+            <li><a href="/retours">Retours</a></li>
           </ul>
         </div>
         <div>
           <h3 className="font-bold mb-2">SÉLECTIONS</h3>
           <ul className="space-y-1">
-            <li><a href="#">Manteaux & Trenchs</a></li>
-            <li><a href="#">Robes</a></li>
-            <li><a href="#">Chemises</a></li>
+            <li><a href="/manteaux-trenchs">Manteaux & Trenchs</a></li>
+            <li><a href="/robes">Robes</a></li>
+            <li><a href="/chemises">Chemises</a></li>
           </ul>
         </div>
         <div>
           <h3 className="font-bold mb-2">SÉLECTIONS</h3>
           <ul className="space-y-1">
-            <li><a href="#">Jupes</a></li>
-            <li><a href="#">Shorts</a></li>
-            <li><a href="#">Combinaisons</a></li>
+            <li><a href="/jupes">Jupes</a></li>
+            <li><a href="/shorts">Shorts</a></li>
+            <li><a href="/combinaisons">Combinaisons</a></li>
           </ul>
         </div>
         <div>
           <h3 className="font-bold mb-2">INFORMATIONS</h3>
           <ul className="space-y-1">
-            <li><a href="#">CGV</a></li>
-            <li><a href="#">Mentions légales</a></li>
-            <li><a href="#">Données personnelles</a></li>
-            <li><a href="#">Nous rejoindre</a></li>
+            <li><a href="/cgv">CGV</a></li>
+            <li><a href="/mentions-legales">Mentions légales</a></li>
+            <li><a href="/donnees-personnelles">Données personnelles</a></li>
+            <li><a href="/nous-rejoindre">Nous rejoindre</a></li>
           </ul>
         </div>
         <div>
           <h3 className="font-bold mb-2">NAF NAF</h3>
           <ul className="space-y-1">
-            <li><a href="#">La Marque</a></li>
+            <li><a href="/la-marque">La Marque</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-bold mb-2">PAGES</h3>
+          <ul className="space-y-1">
+            <li><a href="/">Accueil</a></li>
+            <li><a href="/products">Produits</a></li>
+            <li><a href="/about">À propos</a></li>
+            <li><a href="/cart">Panier</a></li>
+            <li><a href="/checkout">Paiement</a></li>
+            <li><a href="/wishlist">Favoris</a></li>
+            <li><a href="/profile">Profil</a></li>
+            <li><a href="/orders">Commandes</a></li>
+            <li><a href="/auth">Connexion</a></li>
           </ul>
         </div>
       </div>

--- a/client/src/pages/boutiques.tsx
+++ b/client/src/pages/boutiques.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function Boutiques() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Nos boutiques</h1>
+        <p className="text-gray-600">Découvrez nos différents points de vente NAF NAF.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/cgv.tsx
+++ b/client/src/pages/cgv.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function CGV() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Conditions Générales de Vente</h1>
+        <p className="text-gray-600">Consultez nos conditions générales de vente.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/chemises.tsx
+++ b/client/src/pages/chemises.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function Chemises() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Chemises</h1>
+        <p className="text-gray-600">Parcourez notre sélection de chemises élégantes.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/combinaisons.tsx
+++ b/client/src/pages/combinaisons.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function Combinaisons() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Combinaisons</h1>
+        <p className="text-gray-600">Explorez nos combinaisons élégantes et confortables.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/contact.tsx
+++ b/client/src/pages/contact.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function Contact() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Contact</h1>
+        <p className="text-gray-600">Entrez en contact avec notre service client.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/donnees-personnelles.tsx
+++ b/client/src/pages/donnees-personnelles.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function DonneesPersonnelles() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Données personnelles</h1>
+        <p className="text-gray-600">Découvrez comment nous protégeons vos données personnelles.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/faq.tsx
+++ b/client/src/pages/faq.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function FAQ() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">FAQ</h1>
+        <p className="text-gray-600">Questions fréquentes sur nos services et produits.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/jupes.tsx
+++ b/client/src/pages/jupes.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function Jupes() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Jupes</h1>
+        <p className="text-gray-600">Découvrez notre collection de jupes féminines.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/la-marque.tsx
+++ b/client/src/pages/la-marque.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function LaMarque() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">La Marque</h1>
+        <p className="text-gray-600">En savoir plus sur l'univers NAF NAF.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/livraison.tsx
+++ b/client/src/pages/livraison.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function Livraison() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Livraison</h1>
+        <p className="text-gray-600">Informations sur nos options de livraison.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/manteaux-trenchs.tsx
+++ b/client/src/pages/manteaux-trenchs.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function ManteauxTrenchs() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Manteaux & Trenchs</h1>
+        <p className="text-gray-600">Explorez notre collection de manteaux et trenchs.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/mentions-legales.tsx
+++ b/client/src/pages/mentions-legales.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function MentionsLegales() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Mentions légales</h1>
+        <p className="text-gray-600">Informations légales sur NAF NAF.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/nous-rejoindre.tsx
+++ b/client/src/pages/nous-rejoindre.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function NousRejoindre() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Nous rejoindre</h1>
+        <p className="text-gray-600">Découvrez les opportunités pour rejoindre notre équipe.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/retours.tsx
+++ b/client/src/pages/retours.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function Retours() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Retours</h1>
+        <p className="text-gray-600">Consultez notre politique de retour.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/robes.tsx
+++ b/client/src/pages/robes.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function Robes() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Robes</h1>
+        <p className="text-gray-600">Découvrez nos dernières robes tendance.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/shorts.tsx
+++ b/client/src/pages/shorts.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/layout/header";
+import { Footer } from "@/components/layout/footer";
+
+export default function Shorts() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Shorts</h1>
+        <p className="text-gray-600">Trouvez le short parfait pour chaque occasion.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Link service, selection, and information footer links to dedicated routes
- Provide placeholder pages for each footer destination and register them in the router

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_68970a97eb788329b7423d58b298884b