### PR TITLE
Fix rating fields and add nodemailer types

### DIFF
--- a/client/src/components/products/product-card.tsx
+++ b/client/src/components/products/product-card.tsx
@@ -166,9 +166,12 @@ export function ProductCard({ product }: ProductCardProps) {
 
           {/* Rating */}
           <div className="flex items-center space-x-1">
-            <StarRating value={parseFloat(product.rating || "0")} size="sm" />
+            <StarRating
+              value={parseFloat(product.averageRating || "0")}
+              size="sm"
+            />
             <span className="text-gray-600 text-sm" data-testid={`product-review-count-${product.id}`}>
-              ({product.reviewCount || 0})
+              ({product.reviewsCount || 0})
             </span>
           </div>
         </div>

--- a/client/src/pages/products.tsx
+++ b/client/src/pages/products.tsx
@@ -83,7 +83,10 @@ export default function Products() {
       case "name":
         return a.name.localeCompare(b.name);
       case "rating":
-        return parseFloat(b.rating || "0") - parseFloat(a.rating || "0");
+        return (
+          parseFloat(b.averageRating || "0") -
+          parseFloat(a.averageRating || "0")
+        );
       case "newest":
       default:
         return (

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -34,8 +34,8 @@ async function seed() {
       tags: ["soirée", "élégant"],
       shortDescription: "Une robe idéale pour les occasions spéciales.",
       description: "Cette robe élégante offre une coupe flatteuse et un tissu de qualité supérieure.",
-      rating: "4.5",
-      reviewCount: 12,
+      averageRating: "4.5",
+      reviewsCount: 12,
     });
 
     console.log("✅ Seed terminé avec succès");

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -157,7 +157,10 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createCategory(category: InsertCategory): Promise<Category> {
-    const [newCategory] = await db.insert(categories).values(category).returning();
+    const [newCategory] = (await db
+      .insert(categories)
+      .values(category)
+      .returning()) as Category[];
     return newCategory;
   }
 
@@ -413,8 +416,8 @@ export class DatabaseStorage implements IStorage {
     await db
       .update(products)
       .set({
-        rating: stats.avg ? stats.avg.toFixed(2) : "0",
-        reviewCount: stats.count,
+        averageRating: stats.avg ? stats.avg.toFixed(2) : "0",
+        reviewsCount: stats.count,
       })
       .where(eq(products.id, review.productId));
 

--- a/server/types/nodemailer.d.ts
+++ b/server/types/nodemailer.d.ts
@@ -1,0 +1,1 @@
+declare module "nodemailer";

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -50,7 +50,7 @@ export const users = pgTable(
 
 /* -------------------------------- Categories -------------------------------- */
 
-export const categories = pgTable(
+export const categories: any = pgTable(
   "categories",
   {
     id: serial("id").primaryKey(),
@@ -58,7 +58,7 @@ export const categories = pgTable(
     slug: varchar("slug", { length: 255 }).notNull().unique(),
     description: text("description"),
     imageUrl: varchar("image_url", { length: 1024 }),
-    parentId: integer("parent_id").references(() => categories.id, {
+    parentId: integer("parent_id").references((): any => categories.id, {
       onDelete: "set null",
     }),
     isActive: boolean("is_active").notNull().default(true),


### PR DESCRIPTION
## Summary
- update product rating references to use averageRating and reviewsCount
- adjust product review aggregation and category creation handling
- add nodemailer module declaration for TypeScript

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit --pretty false`


------
https://chatgpt.com/codex/tasks/task_b_689a37266fdc8329be542a2f1634b731