### PR TITLE
fix: enable contact form email delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,12 @@ GOOGLE_CALLBACK_PATH=/api/callback
 KONNECT_API_BASE=https://api.konnect.network
 KONNECT_API_KEY=your_konnect_api_key
 KONNECT_AUTH_SCHEME=Bearer
+
+# --- Gmail SMTP (mot de passe d'application requis) ---
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=465
+SMTP_USER=your_email@gmail.com
+SMTP_PASS=your_app_password
+
+# Destinataire des messages du formulaire de contact
+CONTACT_TO=your_email@gmail.com

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { setupAuth, isAuthenticated } from "./auth";
 import paymentRouter from "./payments";
+import contactRouter from "./routes/contact";
 import { insertProductSchema, insertCategorySchema, insertOrderSchema, insertCartItemSchema, insertReviewSchema, insertNewsletterSchema } from "@shared/schema";
 import { z } from "zod";
 
@@ -34,6 +35,9 @@ app.get("/api/auth/user", (req, res) => {
 
   // Payment routes
   app.use("/api/payments", isAuthenticated, paymentRouter);
+
+  // Contact form route
+  app.use("/api/contact", contactRouter);
 
   // Newsletter subscription route
   app.post('/api/newsletter', async (req, res) => {


### PR DESCRIPTION
## Summary
- wire up contact form API route
- document required SMTP env vars for contact form

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689a39f1db848329b1d08500aadecad6