### PR TITLE
feat: newsletter signup with first-order discount

### DIFF
--- a/client/src/components/layout/footer.tsx
+++ b/client/src/components/layout/footer.tsx
@@ -4,14 +4,21 @@ import { Lock, Truck, RotateCcw, Headphones, Instagram, Facebook } from "lucide-
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 
 export function Footer() {
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
   const [message, setMessage] = useState("");
+  const queryClient = useQueryClient();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setStatus("error");
+      setMessage("Adresse email invalide");
+      return;
+    }
     try {
       const res = await fetch("/api/newsletter", {
         method: "POST",
@@ -19,10 +26,14 @@ export function Footer() {
         body: JSON.stringify({ email }),
       });
       const data = await res.json();
+      if (res.status === 409) {
+        throw new Error(data.message || "Cet email est déjà inscrit");
+      }
       if (!res.ok) throw new Error(data.message || "Une erreur s'est produite");
       setStatus("success");
       setMessage("Merci pour votre inscription !");
       setEmail("");
+      queryClient.invalidateQueries({ queryKey: ["/api/newsletter/status"] });
     } catch (err: any) {
       setStatus("error");
       setMessage(err.message || "Une erreur s'est produite");

--- a/client/src/pages/cart.tsx
+++ b/client/src/pages/cart.tsx
@@ -24,6 +24,11 @@ export default function Cart() {
     enabled: isAuthenticated,
   });
 
+  const { data: newsletterStatus } = useQuery({
+    queryKey: ["/api/newsletter/status"],
+    enabled: isAuthenticated,
+  });
+
   const updateQuantityMutation = useMutation({
     mutationFn: async ({ id, quantity }: { id: number; quantity: number }) => {
       await apiRequest("PUT", `/api/cart/${id}`, { quantity });
@@ -159,7 +164,8 @@ export default function Cart() {
 
   const shipping = subtotal >= 150 ? 0 : 7; // Free shipping over 150 DT
   const tax = subtotal * 0.19; // 19% VAT
-  const total = subtotal + shipping + tax;
+  const discount = newsletterStatus?.discountAvailable ? subtotal * 0.1 : 0;
+  const total = subtotal + shipping + tax - discount;
 
   return (
     <div className="min-h-screen">
@@ -326,9 +332,16 @@ export default function Cart() {
                     <span>TVA (19%)</span>
                     <span data-testid="cart-tax">{tax.toFixed(2)} DT</span>
                   </div>
-                  
+
+                  {discount > 0 && (
+                    <div className="flex justify-between text-green-600">
+                      <span>Réduction newsletter</span>
+                      <span data-testid="cart-discount">-{discount.toFixed(2)} DT</span>
+                    </div>
+                  )}
+
                   <Separator />
-                  
+
                   <div className="flex justify-between text-lg font-semibold">
                     <span>Total</span>
                     <span className="text-primary" data-testid="cart-total">

--- a/client/src/pages/checkout.tsx
+++ b/client/src/pages/checkout.tsx
@@ -65,6 +65,11 @@ export default function Checkout() {
     enabled: isAuthenticated,
   });
 
+  const { data: newsletterStatus } = useQuery({
+    queryKey: ["/api/newsletter/status"],
+    enabled: isAuthenticated,
+  });
+
   const createOrderMutation = useMutation({
     mutationFn: async (orderData: any) => {
       const response = await apiRequest("POST", "/api/orders", orderData);
@@ -146,7 +151,8 @@ export default function Checkout() {
 
   const shipping = subtotal >= 150 ? 0 : 7;
   const tax = subtotal * 0.19;
-  const total = subtotal + shipping + tax;
+  const discount = newsletterStatus?.discountAvailable ? subtotal * 0.1 : 0;
+  const total = subtotal + shipping + tax - discount;
 
   const handleAddressChange = (field: keyof ShippingAddress, value: string, isShipping = true) => {
     if (isShipping) {
@@ -201,6 +207,7 @@ export default function Checkout() {
       subtotal: subtotal.toFixed(2),
       tax: tax.toFixed(2),
       shipping: shipping.toFixed(2),
+      discount: discount.toFixed(2),
       shippingAddress,
       billingAddress: sameAsBilling ? shippingAddress : billingAddress,
       paymentMethod,
@@ -562,9 +569,16 @@ export default function Checkout() {
                   <span>TVA (19%)</span>
                   <span data-testid="summary-tax">{tax.toFixed(2)} DT</span>
                 </div>
-                
+
+                {discount > 0 && (
+                  <div className="flex justify-between text-green-600">
+                    <span>Réduction newsletter</span>
+                    <span data-testid="summary-discount">-{discount.toFixed(2)} DT</span>
+                  </div>
+                )}
+
                 <Separator />
-                
+
                 <div className="flex justify-between text-lg font-semibold">
                   <span>Total</span>
                   <span className="text-primary" data-testid="summary-total">

--- a/drizzle/0002_newsletter_discount.sql
+++ b/drizzle/0002_newsletter_discount.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "newsletter_subscriptions" ADD COLUMN "discount_used" boolean DEFAULT false NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "orders" ADD COLUMN "discount" numeric(10,2) DEFAULT '0' NOT NULL;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,772 @@
+{
+  "id": "9ed3b6df-0893-44fe-8ba3-e4e68b7f7eb6",
+  "prevId": "29cfb21d-0e74-4571-bcd6-4d985008e009",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.cart_items": {
+      "name": "cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscriptions": {
+      "name": "newsletter_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "discount_used": {
+          "name": "discount_used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscriptions_email_unique": {
+          "name": "newsletter_subscriptions_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "shipping": {
+          "name": "shipping",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "shipping_address": {
+          "name": "shipping_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "order_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sale_price": {
+          "name": "sale_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "sizes": {
+          "name": "sizes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "colors": {
+          "name": "colors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "products_sku_unique": {
+          "name": "products_sku_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sku"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sess": {
+          "name": "sess",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_session_expire": {
+          "name": "IDX_session_expire",
+          "columns": [
+            {
+              "expression": "expire",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -14,7 +14,13 @@
       "version": "7",
       "when": 1754778279025,
       "tag": "0001_youthful_rogue",
-
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1755016789000,
+      "tag": "0002_newsletter_discount",
       "breakpoints": true
     }
   ]

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -43,11 +43,35 @@ app.get("/api/auth/user", (req, res) => {
   app.post('/api/newsletter', async (req, res) => {
     try {
       const data = insertNewsletterSchema.parse(req.body);
-      const subscription = await storage.createNewsletterSubscription(data);
+      const { subscription, isNew } = await storage.createNewsletterSubscription(data);
+      if (!isNew) {
+        return res.status(409).json({ message: 'Cet email est déjà inscrit à la newsletter' });
+      }
       res.json(subscription);
     } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ message: 'Adresse email invalide' });
+      }
       console.error('Error subscribing to newsletter:', error);
       res.status(500).json({ message: 'Failed to subscribe to newsletter' });
+    }
+  });
+
+  // Newsletter status route
+  app.get('/api/newsletter/status', isAuthenticated, async (req: any, res) => {
+    try {
+      const user = await storage.getUser(req.user.id);
+      if (!user?.email) {
+        return res.json({ subscribed: false, discountAvailable: false });
+      }
+      const sub = await storage.getNewsletterSubscription(user.email);
+      res.json({
+        subscribed: !!sub,
+        discountAvailable: !!sub && !sub.discountUsed,
+      });
+    } catch (error) {
+      console.error('Error fetching newsletter status:', error);
+      res.status(500).json({ message: 'Failed to fetch newsletter status' });
     }
   });
 
@@ -378,7 +402,26 @@ app.get("/api/auth/user", (req, res) => {
     try {
       const userId = req.user.id;
       const orderData = insertOrderSchema.parse({ ...req.body, userId });
+      const user = await storage.getUser(userId);
+      const subtotal = parseFloat(orderData.subtotal as any);
+      const tax = parseFloat(orderData.tax as any);
+      const shipping = parseFloat(orderData.shipping as any);
+      let discount = 0;
+      if (user?.email) {
+        const sub = await storage.getNewsletterSubscription(user.email);
+        if (sub && !sub.discountUsed) {
+          discount = subtotal * 0.1;
+        }
+      }
+      orderData.discount = discount.toFixed(2) as any;
+      orderData.total = (subtotal + tax + shipping - discount).toFixed(2) as any;
+
       const order = await storage.createOrder(orderData);
+
+      if (discount > 0 && user?.email) {
+        await storage.markNewsletterDiscountUsed(user.email);
+      }
+
       res.json(order);
     } catch (error) {
       console.error("Error creating order:", error);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -80,7 +80,11 @@ export interface IStorage {
   createReview(review: InsertReview): Promise<Review>;
 
   // Newsletter operations
-  createNewsletterSubscription(sub: InsertNewsletterSubscription): Promise<NewsletterSubscription>;
+  createNewsletterSubscription(
+    sub: InsertNewsletterSubscription,
+  ): Promise<{ subscription: NewsletterSubscription; isNew: boolean }>;
+  getNewsletterSubscription(email: string): Promise<NewsletterSubscription | undefined>;
+  markNewsletterDiscountUsed(email: string): Promise<void>;
 
   // Admin operations
   getOrderStats(): Promise<{
@@ -424,21 +428,42 @@ export class DatabaseStorage implements IStorage {
     return newReview;
   }
 
-  async createNewsletterSubscription(sub: InsertNewsletterSubscription): Promise<NewsletterSubscription> {
+  async createNewsletterSubscription(
+    sub: InsertNewsletterSubscription,
+  ): Promise<{ subscription: NewsletterSubscription; isNew: boolean }> {
     const [subscription] = await db
       .insert(newsletterSubscriptions)
       .values(sub)
       .onConflictDoNothing()
       .returning();
 
-    if (subscription) return subscription;
+    if (subscription) {
+      return { subscription, isNew: true };
+    }
 
     const [existing] = await db
       .select()
       .from(newsletterSubscriptions)
       .where(eq(newsletterSubscriptions.email, sub.email));
 
-    return existing!;
+    return { subscription: existing!, isNew: false };
+  }
+
+  async getNewsletterSubscription(
+    email: string,
+  ): Promise<NewsletterSubscription | undefined> {
+    const [subscription] = await db
+      .select()
+      .from(newsletterSubscriptions)
+      .where(eq(newsletterSubscriptions.email, email));
+    return subscription;
+  }
+
+  async markNewsletterDiscountUsed(email: string): Promise<void> {
+    await db
+      .update(newsletterSubscriptions)
+      .set({ discountUsed: true })
+      .where(eq(newsletterSubscriptions.email, email));
   }
 
   // Admin operations

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -143,6 +143,9 @@ export const orders = pgTable(
     shipping: numeric("shipping", { precision: 10, scale: 2 })
       .notNull()
       .default("0"),
+    discount: numeric("discount", { precision: 10, scale: 2 })
+      .notNull()
+      .default("0"),
 
     shippingAddress: jsonb("shipping_address").notNull(),
     billingAddress: jsonb("billing_address"),
@@ -244,6 +247,7 @@ export const newsletterSubscriptions = pgTable(
     id: serial("id").primaryKey(),
     email: varchar("email", { length: 255 }).notNull().unique(),
     createdAt: timestamp("created_at", { withTimezone: false }).defaultNow(),
+    discountUsed: boolean("discount_used").notNull().default(false),
   },
 );
 
@@ -368,6 +372,7 @@ export const insertNewsletterSchema = createInsertSchema(
 ).omit({
   id: true,
   createdAt: true,
+  discountUsed: true,
 });
 
 /* ---------------------------------- Types ---------------------------------- */


### PR DESCRIPTION
## Summary
- allow users to subscribe to newsletter with validation and duplicate handling
- grant one-time 10% discount for newsletter subscribers on their first order
- show newsletter discount in cart and checkout and persist via new DB columns

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_689b6ce6443c8329bd6dba71a1f857f8