### PR TITLE
Fix Google OAuth user upsert logic

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -60,19 +60,22 @@ export async function setupAuth(app: Express): Promise<void> {
         clientSecret: GOOGLE_CLIENT_SECRET,
         callbackURL,
       },
-      async (_accessToken, _refreshToken, profile, done) => {
-        const userData = {
-          id: profile.id,
-          email: profile.emails?.[0]?.value || "",
-          firstName: profile.name?.givenName,
-          lastName: profile.name?.familyName,
-          profileImageUrl: profile.photos?.[0]?.value,
-        };
-        const fullUser = await storage.upsertUser(userData); // <- assure-toi que ça retourne le role aussi
-        done(null, fullUser);
-      }
-    )
-  );
+        async (_accessToken, _refreshToken, profile, done) => {
+          const email = profile.emails?.[0]?.value;
+          if (!email) {
+            return done(new Error("Google account has no email"));
+          }
+          const userData = {
+            email,
+            firstName: profile.name?.givenName,
+            lastName: profile.name?.familyName,
+            profileImageUrl: profile.photos?.[0]?.value,
+          };
+          const fullUser = await storage.upsertUser(userData); // <- assure-toi que ça retourne le role aussi
+          done(null, fullUser);
+        }
+      )
+    );
 
   passport.use(
     new LocalStrategy({ usernameField: "email" }, async (email, password, done) => {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -116,15 +116,19 @@ export class DatabaseStorage implements IStorage {
   }
 
   async upsertUser(userData: UpsertUser): Promise<User> {
+    // We upsert on the email field to avoid creating duplicate users when the
+    // same person signs in with Google after registering with email/password.
+    // The primary key (id) should remain stable, so we exclude it from the
+    // update set in case of conflict.
+    const updateData = { ...userData, updatedAt: new Date() } as any;
+    delete updateData.id;
+
     const [user] = await db
       .insert(users)
       .values(userData)
       .onConflictDoUpdate({
-        target: users.id,
-        set: {
-          ...userData,
-          updatedAt: new Date(),
-        },
+        target: users.email,
+        set: updateData,
       })
       .returning();
     return user;


### PR DESCRIPTION
## Summary
- avoid duplicating users when signing in with Google by upserting on email rather than id
- validate Google profile includes email before creating or updating user

## Testing
- `npm run check` *(fails: Property 'discountAvailable' does not exist on type '{}')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_689b960f2efc8329a00cb54609e71862