### PR TITLE
fix: handle google oauth callback path

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ SESSION_SECRET=085e572852278930eca8548db8080a5ac5cf2bea7420f2c90fcd746814271aa3a
 GOOGLE_CLIENT_ID=69844677397-fqk3h0cpht10lq0tk5gmudobbl4cqfjf.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=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
 PUBLIC_BASE_URL=http://localhost:5000
-GOOGLE_CALLBACK_PATH=http://localhost:5000/api/callback
+GOOGLE_CALLBACK_PATH=/api/callback
 
 
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -52,6 +52,7 @@ export async function setupAuth(app: Express): Promise<void> {
   app.use(passport.session());
 
   const callbackURL = new URL(GOOGLE_CALLBACK_PATH, PUBLIC_BASE_URL).toString();
+  const callbackPath = new URL(callbackURL).pathname;
 
   passport.use(
     new GoogleStrategy(
@@ -101,7 +102,7 @@ export async function setupAuth(app: Express): Promise<void> {
   app.get("/api/login", passport.authenticate("google", { scope: ["profile", "email"] }));
 
   app.get(
-    GOOGLE_CALLBACK_PATH,
+    callbackPath,
     passport.authenticate("google", {
       successReturnToOrRedirect: "/",
       failureRedirect: "/api/login",
@@ -159,7 +160,7 @@ export async function setupAuth(app: Express): Promise<void> {
   app.post("/api/logout", logoutHandler);
   app.get("/api/logout", logoutHandler);
 
-  console.log(`[auth] Google OAuth prêt (callback: ${callbackURL})`);
+    console.log(`[auth] Google OAuth prêt (callback: ${callbackURL})`);
 }
 
 export const isAuthenticated: RequestHandler = (req, res, next) => {


### PR DESCRIPTION
## Summary
- derive Google OAuth callback path from full URL to ensure Express route matches
- standardize GOOGLE_CALLBACK_PATH env var to be relative

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check` (fails: Cannot find type definition file for 'node', Cannot find type definition file for 'vite/client')

------
https://chatgpt.com/codex/tasks/task_b_689ba69f682c83298dd0e939b85f335a