### PR TITLE
Add Render deployment configuration and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ npm start
 
 The Express server automatically listens on the port provided via `PORT` and serves the Vite build output from `dist/public`. A basic health check is exposed at `/api/health`.
 
+### Deploying on Render
+
+Render can use the included `render.yaml` to build and start the app. The configuration runs `npm install && npm run build` during the build phase and `npm start` to launch the production server, ensuring static assets are available before the server starts.
+
 ## API Endpoints
 
 ### Authentication

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "tsx watch server/index.ts",
+    "dev": "cross-env NODE_ENV=development tsx watch server/index.ts",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build",
     "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist/server",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: elegance
+    env: node
+    buildCommand: npm install && npm run build
+    startCommand: npm start
+    envVars:
+      - key: NODE_VERSION
+        value: 22.16.0


### PR DESCRIPTION
## Summary
- ensure `npm run dev` always runs in development mode
- document Render deployment steps
- add Render service configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689dfea740188329bfbc13eb6e63c087