### PR TITLE
fix: support external API via env and rewrites

### DIFF
--- a/client/src/components/cart/cart-modal.tsx
+++ b/client/src/components/cart/cart-modal.tsx
@@ -10,6 +10,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { Link } from "wouter";
 import type { CartItem, Product } from "@shared/schema";
+import { API_BASE } from "@/lib/api";
 
 interface CartModalProps {
   isOpen: boolean;
@@ -41,7 +42,7 @@ export function CartModal({ isOpen, onClose }: CartModalProps) {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }
@@ -72,7 +73,7 @@ export function CartModal({ isOpen, onClose }: CartModalProps) {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }
@@ -110,7 +111,7 @@ export function CartModal({ isOpen, onClose }: CartModalProps) {
           </SheetHeader>
           <div className="flex flex-col items-center justify-center h-full text-center">
             <p className="text-gray-600 mb-4">Vous devez être connecté pour voir votre panier.</p>
-            <Button onClick={() => window.location.href = "/api/login"} data-testid="cart-login-button">
+            <Button onClick={() => (window.location.href = `${API_BASE}/api/login`)} data-testid="cart-login-button">
               Se connecter
             </Button>
           </div>

--- a/client/src/components/layout/footer.tsx
+++ b/client/src/components/layout/footer.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { API_BASE } from "@/lib/api";
 
 export function Footer() {
   const [email, setEmail] = useState("");
@@ -20,7 +21,7 @@ export function Footer() {
       return;
     }
     try {
-      const res = await fetch("/api/newsletter", {
+      const res = await fetch(`${API_BASE}/api/newsletter`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -8,6 +8,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useAuth } from "@/hooks/useAuth";
 import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "@/lib/api";
 import { CartModal } from "@/components/cart/cart-modal";
 import type { CartItem, Product } from "@shared/schema";
 import { useFavorites } from "@/hooks/useFavorites";
@@ -206,7 +207,7 @@ export function Header() {
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
                       className="cursor-pointer"
-                      onClick={() => window.location.href = "/api/logout"}
+                      onClick={() => (window.location.href = `${API_BASE}/api/logout`)}
                     >
                       <LogOut className="mr-2 h-4 w-4" />
                       <span>Déconnexion</span>

--- a/client/src/components/products/product-card.tsx
+++ b/client/src/components/products/product-card.tsx
@@ -11,6 +11,7 @@ import { useFavorites } from "@/hooks/useFavorites";
 import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { Link } from "wouter";
+import { API_BASE } from "@/lib/api";
 
 interface ProductCardProps {
   product: any;
@@ -45,7 +46,7 @@ export function ProductCard({ product }: ProductCardProps) {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "@/lib/api";
 
 async function fetchAuthUser() {
-  const res = await fetch("/api/auth/user", { credentials: "include" });
+  const res = await fetch(`${API_BASE}/api/auth/user`, { credentials: "include" });
 
   if (res.status === 401) {
     return { user: null }; // ✅ au lieu de throw

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,20 @@
+export const API_BASE = import.meta.env.VITE_API_URL ?? "";
+
+export async function api(path: string, init?: RequestInit) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    credentials: "include",
+    ...init,
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function apiRaw(path: string, init?: RequestInit) {
+  return fetch(`${API_BASE}${path}`, {
+    credentials: "include",
+    ...init,
+  });
+}
+

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { API_BASE } from "./api";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -8,9 +9,12 @@ async function throwIfResNotOk(res: Response) {
 }
 
 export async function apiRequest(
-method: string, url: string, data?: unknown | undefined, p0?: { cache: string; headers: { "Cache-Control": string; }; },
+  method: string,
+  url: string,
+  data?: unknown | undefined,
+  _options?: { cache: string; headers: { "Cache-Control": string } },
 ): Promise<Response> {
-  const res = await fetch(url, {
+  const res = await fetch(`${API_BASE}${url}`, {
     method,
     headers: data ? { "Content-Type": "application/json" } : {},
     body: data ? JSON.stringify(data) : undefined,
@@ -27,7 +31,7 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey.join("/") as string, {
+    const res = await fetch(`${API_BASE}${queryKey.join("/") as string}`, {
       credentials: "include",
     });
 

--- a/client/src/pages/admin/categories.tsx
+++ b/client/src/pages/admin/categories.tsx
@@ -20,6 +20,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { Link } from "wouter";
 import type { Category, InsertCategory } from "@shared/schema";
+import { API_BASE } from "@/lib/api";
 
 interface CategoryFormData {
   name: string;
@@ -78,7 +79,7 @@ export default function AdminCategories() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
       } else {
         toast({
@@ -109,7 +110,7 @@ export default function AdminCategories() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
       } else {
         toast({

--- a/client/src/pages/admin/customers.tsx
+++ b/client/src/pages/admin/customers.tsx
@@ -13,6 +13,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { Link } from "wouter";
+import { API_BASE } from "@/lib/api";
 
 export default function AdminCustomers() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -159,7 +160,7 @@ export default function AdminCustomers() {
                 <Button asChild variant="outline">
                   <Link href="/">Voir le site</Link>
                 </Button>
-                <Button onClick={() => window.location.href = "/api/logout"} variant="outline">
+                <Button onClick={() => (window.location.href = `${API_BASE}/api/logout`)} variant="outline">
                   Déconnexion
                 </Button>
               </div>

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -37,6 +37,7 @@ import {
   Pie,
   Cell,
 } from "recharts";
+import { API_BASE } from "@/lib/api";
 
 // ---------- Types ----------
 interface AdminStats {
@@ -198,7 +199,7 @@ export default function AdminDashboard() {
               <h1 className="text-2xl font-semibold">Tableau de bord</h1>
               <div className="flex items-center gap-3">
                 <Button asChild variant="outline"><Link href="/"><Eye className="mr-2 h-4 w-4"/>Voir le site</Link></Button>
-                <Button variant="outline" onClick={() => (window.location.href = "/api/logout")}> <LogOut className="mr-2 h-4 w-4"/>Déconnexion</Button>
+                <Button variant="outline" onClick={() => (window.location.href = `${API_BASE}/api/logout`)}> <LogOut className="mr-2 h-4 w-4"/>Déconnexion</Button>
               </div>
             </div>
           </header>

--- a/client/src/pages/admin/orders.tsx
+++ b/client/src/pages/admin/orders.tsx
@@ -13,6 +13,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { Link } from "wouter";
+import { API_BASE } from "@/lib/api";
 
 export default function AdminOrders() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -65,7 +66,7 @@ export default function AdminOrders() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }
@@ -200,7 +201,7 @@ export default function AdminOrders() {
                 <Button asChild variant="outline">
                   <Link href="/">Voir le site</Link>
                 </Button>
-                <Button onClick={() => window.location.href = "/api/logout"} variant="outline">
+                <Button onClick={() => (window.location.href = `${API_BASE}/api/logout`)} variant="outline">
                   Déconnexion
                 </Button>
               </div>

--- a/client/src/pages/admin/products.tsx
+++ b/client/src/pages/admin/products.tsx
@@ -30,6 +30,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { Link } from "wouter";
 import type { Product, Category } from "@shared/schema";
+import { API_BASE } from "@/lib/api";
 
 interface ProductFormData {
   name: string;
@@ -124,7 +125,7 @@ export default function AdminProducts() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }
@@ -157,7 +158,7 @@ export default function AdminProducts() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }
@@ -188,7 +189,7 @@ export default function AdminProducts() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }

--- a/client/src/pages/auth.tsx
+++ b/client/src/pages/auth.tsx
@@ -8,6 +8,7 @@ import { Separator } from "@/components/ui/separator";
 import { useAuth } from "@/hooks/useAuth";
 import { Link } from "wouter";
 import { useForm } from "react-hook-form";
+import { API_BASE } from "@/lib/api";
 
 export default function AuthPage() {
   const { isAuthenticated } = useAuth();
@@ -26,7 +27,7 @@ export default function AuthPage() {
 
   const onSubmit = async (data: any) => {
     const endpoint = mode === "login" ? "/api/auth/login" : "/api/auth/register";
-    const res = await fetch(endpoint, {
+    const res = await fetch(`${API_BASE}${endpoint}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
@@ -125,7 +126,7 @@ export default function AuthPage() {
 
           <div className="space-y-3">
             <Button
-              onClick={() => (window.location.href = "/api/login")}
+              onClick={() => (window.location.href = `${API_BASE}/api/login`)}
               variant="outline"
               className="w-full h-12 border-gray-200 hover:bg-gray-50"
             >

--- a/client/src/pages/cart.tsx
+++ b/client/src/pages/cart.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { Link } from "wouter";
+import { API_BASE } from "@/lib/api";
 
 export default function Cart() {
   const [promoCode, setPromoCode] = useState("");
@@ -44,7 +45,7 @@ export default function Cart() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }
@@ -75,7 +76,7 @@ export default function Cart() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }
@@ -106,7 +107,7 @@ export default function Cart() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }
@@ -148,7 +149,7 @@ export default function Cart() {
           <ShoppingBag className="h-16 w-16 text-gray-400 mx-auto mb-4" />
           <h1 className="text-2xl font-bold text-gray-900 mb-4">Votre panier</h1>
           <p className="text-gray-600 mb-8">Vous devez être connecté pour voir votre panier.</p>
-          <Button onClick={() => window.location.href = "/api/login"} data-testid="cart-login">
+          <Button onClick={() => (window.location.href = `${API_BASE}/api/login`)} data-testid="cart-login">
             Se connecter
           </Button>
         </div>

--- a/client/src/pages/checkout.tsx
+++ b/client/src/pages/checkout.tsx
@@ -16,6 +16,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { Link, useLocation } from "wouter";
+import { API_BASE } from "@/lib/api";
 
 interface ShippingAddress {
   firstName: string;
@@ -91,7 +92,7 @@ export default function Checkout() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }
@@ -117,7 +118,7 @@ export default function Checkout() {
         <div className="container mx-auto px-4 py-16 text-center">
           <h1 className="text-2xl font-bold text-gray-900 mb-4">Commande</h1>
           <p className="text-gray-600 mb-8">Vous devez être connecté pour passer une commande.</p>
-          <Button onClick={() => window.location.href = "/api/login"} data-testid="checkout-login">
+          <Button onClick={() => (window.location.href = `${API_BASE}/api/login`)} data-testid="checkout-login">
             Se connecter
           </Button>
         </div>

--- a/client/src/pages/contact.tsx
+++ b/client/src/pages/contact.tsx
@@ -6,6 +6,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Mail, CheckCircle2, AlertTriangle } from "lucide-react";
+import { API_BASE } from "@/lib/api";
 
 export default function ContactPage() {
   const [name, setName] = useState("");
@@ -28,7 +29,7 @@ export default function ContactPage() {
 
     setSubmitting(true);
     try {
-      const res = await fetch("/api/contact", {
+      const res = await fetch(`${API_BASE}/api/contact`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name, email, message, website }),

--- a/client/src/pages/orders.tsx
+++ b/client/src/pages/orders.tsx
@@ -10,6 +10,7 @@ import { Link } from "wouter";
 import { useEffect } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { fr } from "date-fns/locale";
+import { API_BASE } from "@/lib/api";
 
 function getStatusIcon(status: string) {
   switch (status) {
@@ -73,14 +74,14 @@ export default function Orders() {
   // Redirect to login if not authenticated
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
-      window.location.href = "/api/login";
+      window.location.href = `${API_BASE}/api/login`;
       return;
     }
   }, [isAuthenticated, isLoading]);
 
   const handleDownloadInvoice = async (orderId: number) => {
     try {
-      const res = await fetch(`/api/orders/${orderId}/invoice`, {
+      const res = await fetch(`${API_BASE}/api/orders/${orderId}/invoice`, {
         credentials: "include",
       });
       if (!res.ok) return;

--- a/client/src/pages/product-detail.tsx
+++ b/client/src/pages/product-detail.tsx
@@ -32,6 +32,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { useFavorites } from "@/hooks/useFavorites";
+import { API_BASE } from "@/lib/api";
 
 export default function ProductDetail() {
   const [, params] = useRoute("/products/:slug");
@@ -91,7 +92,7 @@ export default function ProductDetail() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }
@@ -141,7 +142,7 @@ export default function ProductDetail() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = `${API_BASE}/api/login`;
         }, 500);
         return;
       }

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -15,6 +15,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { Link } from "wouter";
+import { API_BASE } from "@/lib/api";
 
 export default function ProfilePage() {
   const { user, isAuthenticated, isLoading } = useAuth();
@@ -126,7 +127,7 @@ export default function ProfilePage() {
               <h1 className="text-3xl font-bold text-gray-900">Mon Profil</h1>
               <p className="text-gray-600">Gérez vos informations personnelles et commandes</p>
             </div>
-            <Button onClick={() => window.location.href = "/api/logout"} variant="outline">
+            <Button onClick={() => (window.location.href = `${API_BASE}/api/logout`)} variant="outline">
               Déconnexion
             </Button>
           </div>
@@ -381,7 +382,7 @@ export default function ProfilePage() {
                         <p className="text-sm text-gray-600 mb-3">
                           Gérez vos données personnelles et vos préférences de confidentialité.
                         </p>
-                        <Button variant="outline" onClick={() => window.location.href = "/api/logout"}>
+                        <Button variant="outline" onClick={() => (window.location.href = `${API_BASE}/api/logout`)}>
                           Se déconnecter
                         </Button>
                       </div>

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist/public",
   "rewrites": [
+    { "source": "/api/(.*)", "destination": "https://YOUR-BACKEND-PROD.example.com/api/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- centralize API base URL via `VITE_API_URL`
- prefix all client API calls and redirects with the external base
- proxy `/api` requests to the backend in `vercel.json`

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689e287c3aa88329b7e5be2f39332365