### PR TITLE
fix: add node auth endpoints

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -24,31 +24,27 @@ export default async function handler(req, res) {
 
   try {
     const body = typeof req.body === 'string' ? JSON.parse(req.body || '{}') : req.body;
-    const { firstName, lastName, email, password } = body;
+    const { email, password } = body;
 
-    if (!firstName || !lastName || !email || !password) {
-      return res.status(400).json({ message: 'Missing required fields' });
+    if (!email || !password) {
+      return res.status(400).json({ message: 'Email and password required' });
     }
 
-    const { rows: existingUsers } = await sql`SELECT id FROM users WHERE email = ${email} LIMIT 1`;
-    if (existingUsers.length > 0) {
-      return res.status(409).json({ message: 'User already exists with this email' });
+    const { rows } = await sql`SELECT id, password_hash, first_name, last_name, email, role FROM users WHERE email = ${email} LIMIT 1`;
+    const user = rows[0];
+
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
     }
 
-    const hashedPassword = await bcrypt.hash(password, 10);
-
-    const { rows: newUsers } = await sql`
-      INSERT INTO users (email, password_hash, first_name, last_name, role, created_at, updated_at)
-      VALUES (${email}, ${hashedPassword}, ${firstName}, ${lastName}, 'customer', NOW(), NOW())
-      RETURNING id, email, first_name, last_name, role
-    `;
-
-    const user = newUsers[0];
+    const valid = await bcrypt.compare(password, user.password_hash);
+    if (!valid) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
 
     res.setHeader('Set-Cookie', `token=${user.id}; HttpOnly; Path=/; Max-Age=${7 * 24 * 60 * 60}; SameSite=Lax`);
 
-    res.status(201).json({
-      message: 'Registration successful',
+    res.status(200).json({
       user: {
         id: user.id,
         email: user.email,
@@ -58,7 +54,7 @@ export default async function handler(req, res) {
       },
     });
   } catch (error) {
-    console.error('Register API error:', error);
+    console.error('Login API error:', error);
     res.status(500).json({ message: 'Internal error' });
   }
 }

--- a/api/auth/user.js
+++ b/api/auth/user.js
@@ -1,11 +1,22 @@
 import { sql } from '@vercel/postgres';
 
-export default async function handler(req, res) {
-  // CORS headers
+export const config = { runtime: 'nodejs' };
+
+function setCors(res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-  
+}
+
+function getToken(req) {
+  const cookie = req.headers.cookie || '';
+  const match = cookie.match(/(?:^|;)\s*token=([^;]+)/);
+  return match ? match[1] : null;
+}
+
+export default async function handler(req, res) {
+  setCors(res);
+
   if (req.method === 'OPTIONS') {
     res.status(200).end();
     return;
@@ -17,40 +28,40 @@ export default async function handler(req, res) {
   }
 
   try {
-    // For basic auth, check Authorization header
-    const authHeader = req.headers.authorization;
-    
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return res.status(200).json({ 
-        user: null, 
-        authenticated: false 
+    const token = getToken(req);
+
+    if (!token) {
+      return res.status(200).json({
+        user: null,
+        authenticated: false,
       });
     }
 
-    // Extract user ID from token (simplified)
-    const token = authHeader.substring(7);
-    
-    // In a real implementation, you'd verify the JWT token here
-    // For now, treat token as user ID for simplicity
-    const { rows } = await sql`SELECT id, email, username, role FROM users WHERE id = ${token} LIMIT 1`;
+    const { rows } = await sql`SELECT id, email, first_name, last_name, role FROM users WHERE id = ${token} LIMIT 1`;
     const user = rows[0];
 
     if (!user) {
-      return res.status(200).json({ 
-        user: null, 
-        authenticated: false 
+      return res.status(200).json({
+        user: null,
+        authenticated: false,
       });
     }
 
-    res.status(200).json({ 
-      user: user, 
-      authenticated: true 
+    res.status(200).json({
+      user: {
+        id: user.id,
+        email: user.email,
+        firstName: user.first_name,
+        lastName: user.last_name,
+        role: user.role,
+      },
+      authenticated: true,
     });
   } catch (error) {
     console.error('Auth user API error:', error);
     res.status(200).json({
       user: null,
-      authenticated: false
+      authenticated: false,
     });
   }
 }

--- a/api/login.js
+++ b/api/login.js
@@ -1,2 +1,3 @@
-
-export { default } from './serverless-handler.js';
+import handler, { config } from './auth/login.js';
+export { config };
+export default handler;


### PR DESCRIPTION
## Summary
- implement POST `/api/auth/login` using `@vercel/postgres` and bcrypt
- handle `/api/auth/register` with first/last name and cookie auth token
- expose auth user endpoint based on cookie token

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS18046 in client/src/pages/admin/dashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_689faeaaf0548329aad517dc5057e49b