### PR TITLE
fix: use absolute register URL

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,4 +1,7 @@
-export const API_BASE = import.meta.env.VITE_API_URL ?? ""; // vide = même origine
+// Normalize API base to avoid accidentally generating relative URLs
+// e.g. when VITE_API_URL is set to "./" which would lead to "./api/..." calls
+const rawApiBase = import.meta.env.VITE_API_URL ?? "";
+export const API_BASE = rawApiBase.startsWith(".") ? "" : rawApiBase; // default: same origin
 
 export async function api(path: string, init?: RequestInit) {
   const res = await fetch(`${API_BASE}${path}`, { credentials: "include", ...init });

--- a/client/src/pages/auth.tsx
+++ b/client/src/pages/auth.tsx
@@ -26,8 +26,9 @@ export default function AuthPage() {
   }
 
   const onSubmit = async (data: any) => {
-    const endpoint = mode === "login" ? "/api/auth/login" : "/api/auth/register";
-    const res = await fetch(`${API_BASE}${endpoint}`, {
+    // Use absolute API paths to avoid relative URL issues
+    const url = mode === "login" ? "/api/auth/login" : "/api/auth/register";
+    const res = await fetch(`${API_BASE}${url}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),


### PR DESCRIPTION
## Summary
- avoid accidental relative API URLs by normalising VITE_API_URL
- ensure auth form uses absolute `/api/auth/*` paths when submitting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in client/src/pages/admin/dashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_689fb255c4c8832997c1abf756b229fe