### PR TITLE
Handle missing database configuration in serverless APIs

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -22,6 +22,12 @@ export default async function handler(req, res) {
     return;
   }
 
+  // Early return if database is not configured
+  if (!process.env.POSTGRES_URL) {
+    res.status(503).json({ message: 'Database not configured' });
+    return;
+  }
+
   try {
     const body = typeof req.body === 'string' ? JSON.parse(req.body || '{}') : req.body;
     const { email, password } = body;

--- a/api/auth/register.js
+++ b/api/auth/register.js
@@ -22,6 +22,12 @@ export default async function handler(req, res) {
     return;
   }
 
+  // Early return if database is not configured
+  if (!process.env.POSTGRES_URL) {
+    res.status(503).json({ message: 'Database not configured' });
+    return;
+  }
+
   try {
     const body = typeof req.body === 'string' ? JSON.parse(req.body || '{}') : req.body;
     const { firstName, lastName, email, password } = body;

--- a/api/auth/user.js
+++ b/api/auth/user.js
@@ -27,6 +27,12 @@ export default async function handler(req, res) {
     return;
   }
 
+  // Early return if database is not configured
+  if (!process.env.POSTGRES_URL) {
+    res.status(200).json({ user: null, authenticated: false });
+    return;
+  }
+
   try {
     const token = getToken(req);
 

--- a/api/categories.js
+++ b/api/categories.js
@@ -5,9 +5,15 @@ export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-  
+
   if (req.method === 'OPTIONS') {
     res.status(200).end();
+    return;
+  }
+
+  // Early return if database is not configured
+  if (!process.env.POSTGRES_URL) {
+    res.status(503).json({ message: 'Database not configured' });
     return;
   }
 

--- a/api/products.js
+++ b/api/products.js
@@ -5,27 +5,33 @@ export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-  
+
   if (req.method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
 
+  // Early return if database is not configured
+  if (!process.env.POSTGRES_URL) {
+    res.status(503).json({ message: 'Database not configured' });
+    return;
+  }
+
   try {
     if (req.method === 'GET') {
-      const { isFeatured, limit = 8 } = req.query;
-      
-      let query = `SELECT p.*, c.name as category_name FROM products p 
-                   LEFT JOIN categories c ON p.category_id = c.id 
-                   WHERE p.is_active = true`;
-      
-      if (isFeatured === 'true') {
-        query += ` AND p.is_featured = true`;
-      }
-      
-      query += ` ORDER BY p.created_at DESC LIMIT ${parseInt(limit)}`;
-      
-      const products = await sql.unsafe(query);
+      const { isFeatured, limit } = req.query;
+      const limitValue = Number.parseInt(limit, 10) || 8;
+
+      const products = await sql`
+        SELECT p.*, c.name as category_name
+        FROM products p
+        LEFT JOIN categories c ON p.category_id = c.id
+        WHERE p.is_active = true
+        ${isFeatured === 'true' ? sql`AND p.is_featured = true` : sql``}
+        ORDER BY p.created_at DESC
+        LIMIT ${limitValue}
+      `;
+
       res.status(200).json({ items: products.rows });
     } else {
       res.status(405).json({ message: 'Method not allowed' });


### PR DESCRIPTION
## Summary
- bail out early in serverless auth, product and category routes when POSTGRES_URL is absent
- replace unsafe product SQL with parameterized query
- simplify auth user route to skip DB lookup when unavailable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS18046 in client/src/pages/admin/dashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_689fc74195d08329933c9f7664606b7f