### PR TITLE
chore: hardcode Google OAuth callback URL

### DIFF
--- a/api/callback.js
+++ b/api/callback.js
@@ -2,6 +2,11 @@
 import jwt from 'jsonwebtoken';
 import { sql } from '@vercel/postgres';
 
+// URL de callback utilisée pour Google OAuth (prod)
+const PUBLIC_BASE_URL = "https://elegance-rho.vercel.app"; // prod
+const CALLBACK_PATH = "/api/callback";
+const REDIRECT_URI = `${PUBLIC_BASE_URL}${CALLBACK_PATH}`;
+
 // Vercel Node functions get global fetch (Node 18+), no need for node-fetch
 
 export default async function handler(req, res) {
@@ -14,9 +19,7 @@ export default async function handler(req, res) {
     const code = req.query.code;
     if (!code) return res.status(400).json({ message: 'Missing code' });
 
-    const base = process.env.PUBLIC_BASE_URL;              // e.g. https://your-app.vercel.app  (NO trailing /)
-    const callbackPath = process.env.GOOGLE_CALLBACK_PATH; // e.g. /api/callback
-    const redirectUri = `${base}${callbackPath}`;
+    const redirectUri = REDIRECT_URI;
 
     // 1) Exchange authorization code -> tokens
     const tokenRes = await fetch('https://oauth2.googleapis.com/token', {

--- a/api/login.js
+++ b/api/login.js
@@ -1,13 +1,16 @@
 // api/login.js
+// URL de callback utilisée pour Google OAuth (prod)
+const PUBLIC_BASE_URL = "https://elegance-rho.vercel.app"; // prod
+const CALLBACK_PATH = "/api/callback";
+const REDIRECT_URI = `${PUBLIC_BASE_URL}${CALLBACK_PATH}`;
+
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
     res.setHeader('Allow', ['GET']);
     return res.status(405).json({ message: 'Method not allowed' });
   }
   try {
-    const base = process.env.PUBLIC_BASE_URL;              // ex: https://ton-domaine.vercel.app
-    const callbackPath = process.env.GOOGLE_CALLBACK_PATH; // ex: /api/callback
-    const redirectUri = `${base}${callbackPath}`;
+    const redirectUri = REDIRECT_URI;
 
     const params = new URLSearchParams({
       client_id: process.env.GOOGLE_CLIENT_ID,

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -9,23 +9,10 @@ import { Strategy as LocalStrategy } from "passport-local";
 import bcrypt from "bcryptjs";
 import { storage } from "./storage";
 
-/** Nettoie un path issu du .env (retire espaces, query, fragment) et garantit un "/" initial */
-function sanitizeCallbackPath(raw: string | undefined, fallback = "/api/callback"): string {
-  const s = (raw ?? fallback).trim();
-  // supprime tout après "#" (fragment) et après "?" (query)
-  const noHash = s.replace(/#.*/, "");
-  const noQuery = noHash.replace(/\?.*/, "");
-  // retire tous les espaces éventuels (évite %20)
-  const noSpaces = noQuery.replace(/\s+/g, "");
-  if (!noSpaces.startsWith("/")) return `/${noSpaces}`;
-  return noSpaces || fallback;
-}
-
-/** Supprime les espaces et le slash final de base URL */
-function sanitizeBaseUrl(raw: string | undefined): string {
-  if (!raw) throw new Error("PUBLIC_BASE_URL manquant dans .env");
-  return raw.trim().replace(/\/+$/, "");
-}
+// URL de callback utilisée pour Google OAuth (prod)
+const PUBLIC_BASE_URL = "https://elegance-rho.vercel.app"; // prod
+const CALLBACK_PATH = "/api/callback";
+const REDIRECT_URI = `${PUBLIC_BASE_URL}${CALLBACK_PATH}`;
 
 export async function setupAuth(app: Express): Promise<void> {
   const {
@@ -33,8 +20,6 @@ export async function setupAuth(app: Express): Promise<void> {
     POSTGRES_URL,
     GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET,
-    PUBLIC_BASE_URL,
-    GOOGLE_CALLBACK_PATH, // peut contenir des espaces/commentaires -> on nettoie
     NODE_ENV,
   } = process.env;
 
@@ -47,15 +32,8 @@ export async function setupAuth(app: Express): Promise<void> {
     );
   }
 
-  const base = sanitizeBaseUrl(PUBLIC_BASE_URL);
-  const cleanPath = sanitizeCallbackPath(GOOGLE_CALLBACK_PATH, "/api/callback");
-
-  // Construit l'URL finale de callback, sans query ni hash
-  const callbackURL = new URL(cleanPath, base + "/");
-  callbackURL.hash = "";
-  callbackURL.search = "";
-  const callbackUrlString = callbackURL.toString(); // p.ex. http://localhost:5000/api/callback
-  const callbackPath = callbackURL.pathname;        // p.ex. /api/callback
+  const callbackUrlString = REDIRECT_URI;
+  const callbackPath = CALLBACK_PATH;
 
   // ---- Sessions ----
   app.set("trust proxy", 1); // requis si on est derrière un proxy (ngrok/railway/etc.)


### PR DESCRIPTION
## Summary
- hardcode production callback URL for Google OAuth in Express auth setup
- reuse the same callback constants in Vercel login and callback handlers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS18046 errors in client/src/pages/admin/dashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a05bab7c348329a4d0ed6b3ac0914b