### PR TITLE
Implement session cookie auth and provide API fallbacks

### DIFF
--- a/api/auth/user.js
+++ b/api/auth/user.js
@@ -1,73 +1,25 @@
-import { sql } from '@vercel/postgres';
+// /api/auth/user.js
+import jwt from "jsonwebtoken";
 
-export const config = { runtime: 'nodejs' };
-
-function setCors(res) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-}
-
-function getToken(req) {
-  const cookie = req.headers.cookie || '';
-  const match = cookie.match(/(?:^|;)\s*token=([^;]+)/);
-  return match ? match[1] : null;
+function getCookie(name, cookieHeader = "") {
+  const m = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
+  return m ? decodeURIComponent(m[1]) : null;
 }
 
 export default async function handler(req, res) {
-  setCors(res);
-
-  if (req.method === 'OPTIONS') {
-    res.status(200).end();
-    return;
-  }
-
-  if (req.method !== 'GET') {
-    res.status(405).json({ message: 'Method not allowed' });
-    return;
-  }
-
-  // Early return if database is not configured
-  if (!process.env.POSTGRES_URL) {
-    res.status(200).json({ user: null, authenticated: false });
-    return;
-  }
-
   try {
-    const token = getToken(req);
+    const token = getCookie("session", req.headers.cookie || "");
+    if (!token) return res.status(401).json({ authenticated: false });
 
-    if (!token) {
-      return res.status(200).json({
-        user: null,
-        authenticated: false,
-      });
-    }
+    const secret = process.env.SESSION_SECRET;
+    const decoded = jwt.verify(token, secret);
 
-    const { rows } = await sql`SELECT id, email, first_name, last_name, role FROM users WHERE id = ${token} LIMIT 1`;
-    const user = rows[0];
-
-    if (!user) {
-      return res.status(200).json({
-        user: null,
-        authenticated: false,
-      });
-    }
-
-    res.status(200).json({
-      user: {
-        id: user.id,
-        email: user.email,
-        firstName: user.first_name,
-        lastName: user.last_name,
-        role: user.role,
-      },
+    return res.status(200).json({
       authenticated: true,
+      user: { id: decoded.sub, email: decoded.email }
     });
-  } catch (error) {
-    console.error('Auth user API error:', error);
-    res.status(200).json({
-      user: null,
-      authenticated: false,
-    });
+  } catch (e) {
+    console.error("[AUTH/USER]", e);
+    return res.status(401).json({ authenticated: false });
   }
 }

--- a/api/callback.js
+++ b/api/callback.js
@@ -14,7 +14,6 @@ export default async function handler(req, res) {
     const base = process.env.PUBLIC_BASE_URL || `https://${req.headers.host}`;
     const redirect_uri = `${base}/api/callback`;
 
-    // 1) code -> tokens
     const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -28,44 +27,27 @@ export default async function handler(req, res) {
     });
     const tokens = await tokenRes.json();
     if (!tokenRes.ok) {
-      console.error("[TOKEN] status", tokenRes.status, tokens);
+      console.error("[TOKEN]", tokenRes.status, tokens);
       return res.status(400).json({ step: "token", error: tokens });
     }
 
-    // 2) userinfo
     const userRes = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
       headers: { Authorization: `Bearer ${tokens.access_token}` },
     });
     const profile = await userRes.json();
     if (!userRes.ok) {
-      console.error("[USERINFO] status", userRes.status, profile);
+      console.error("[USERINFO]", userRes.status, profile);
       return res.status(400).json({ step: "userinfo", error: profile });
     }
 
     const email = profile.email;
-    const firstName = profile.given_name || "";
-    const lastName = profile.family_name || "";
-    const picture = profile.picture || "";
-
     if (!email) return res.status(400).json({ message: "Google profile has no email" });
 
-    // 3) (Optionnel) Upsert DB — garde ton code si besoin, sinon commente pour tester
-    // const upsert = await sql`...`;
-    // const user = upsert.rows[0];
-    // const userId = String(user.id);
+    // Si tu n'utilises pas encore la DB, on peut mettre l'email comme sub
+    const payload = { sub: email, email, provider: "google" };
 
-    // Si tu n'utilises pas la DB, mets un id fake basé sur l'email
-    const userId = email;
-
-    // 🔴 ICI était l'erreur : on définit BIEN payload avant jwt.sign
-    const payload = { sub: userId, email, provider: "google" };
-
-    // 4) JWT
     const secret = process.env.SESSION_SECRET;
-    if (!secret) {
-      console.error("[JWT] SESSION_SECRET missing");
-      return res.status(500).json({ step: "jwt", message: "SESSION_SECRET missing" });
-    }
+    if (!secret) return res.status(500).json({ step: "jwt", message: "SESSION_SECRET missing" });
 
     const sessionToken = jwt.sign(payload, secret, { expiresIn: "7d" });
 
@@ -74,8 +56,7 @@ export default async function handler(req, res) {
       `session=${sessionToken}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${7 * 24 * 60 * 60}`
     );
 
-    // 5) Redirect final
-    return res.redirect("/");
+    return res.redirect(302, "/");
   } catch (e) {
     console.error("[CALLBACK CRASH]", e);
     return res.status(500).json({ message: "Internal error", error: String(e) });

--- a/api/categories.js
+++ b/api/categories.js
@@ -1,7 +1,6 @@
 import { sql } from '@vercel/postgres';
 
 export default async function handler(req, res) {
-  // CORS headers
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
@@ -11,10 +10,8 @@ export default async function handler(req, res) {
     return;
   }
 
-  // Early return if database is not configured
   if (!process.env.POSTGRES_URL) {
-    res.status(503).json({ message: 'Database not configured' });
-    return;
+    return res.status(200).json([{ id: 1, name: 'Test' }]);
   }
 
   try {

--- a/api/products.js
+++ b/api/products.js
@@ -1,7 +1,6 @@
 import { sql } from '@vercel/postgres';
 
 export default async function handler(req, res) {
-  // CORS headers
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
@@ -11,10 +10,8 @@ export default async function handler(req, res) {
     return;
   }
 
-  // Early return if database is not configured
   if (!process.env.POSTGRES_URL) {
-    res.status(503).json({ message: 'Database not configured' });
-    return;
+    return res.status(200).json({ items: [] });
   }
 
   try {


### PR DESCRIPTION
## Summary
- Replace auth user endpoint to verify session JWT cookie and expose authenticated user
- Exchange Google OAuth code for JWT session cookie during callback
- Return safe fallback data from product and category APIs when database is absent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: client/src/pages/admin/dashboard.tsx: 'o' is of type 'unknown')*

------
https://chatgpt.com/codex/tasks/task_b_68a07d79e00c832999faf9e6ad6106fa