### PR TITLE
feat: add logout endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The included `render.yaml` provisions a free PostgreSQL database and configures 
 
 - POST `/api/auth/register` - Register a new user
 - POST `/api/auth/login` - Authenticate user
-- POST `/api/auth/logout` - Logout user
+- GET or POST `/api/logout` - Logout user
 - GET `/api/auth/session` - Get current session
 
 ### Products

--- a/api/logout.js
+++ b/api/logout.js
@@ -1,0 +1,20 @@
+// /api/logout.js
+export default async function handler(req, res) {
+  // On accepte GET (si tu cliques un lien) et POST (si tu fais fetch côté client)
+  if (req.method !== "GET" && req.method !== "POST") {
+    res.setHeader("Allow", ["GET", "POST"]);
+    return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  // Supprime le cookie "session" en l'écrasant avec Max-Age=0
+  res.setHeader(
+    "Set-Cookie",
+    "session=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+  );
+
+  // Empêche toute mise en cache
+  res.setHeader("Cache-Control", "no-store");
+
+  // Redirige vers la home (tu peux changer vers /login si tu veux)
+  return res.redirect(302, "/");
+}


### PR DESCRIPTION
## Summary
- add /api/logout endpoint to clear session cookie and redirect to home
- document logout endpoint in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: 'o' is of type 'unknown' in client/src/pages/admin/dashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a08123cc8483298cf33944094e648d