### PR TITLE
feat: add admin role support

### DIFF
--- a/api/admin/stats.js
+++ b/api/admin/stats.js
@@ -1,0 +1,23 @@
+import { requireAdmin } from '../../lib/auth.js';
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  const user = await requireAdmin(req, res);
+  if (!user) return;
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  // Example admin-only response
+  res.status(200).json({ ok: true });
+}

--- a/api/auth/user.js
+++ b/api/auth/user.js
@@ -1,68 +1,15 @@
-// /api/auth/user.js
-import jwt from "jsonwebtoken";
-import { sql } from "@vercel/postgres";
-
-/** Récupère une valeur de cookie depuis l'en-tête "cookie" */
-function getCookie(name, cookieHeader = "") {
-  const m = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
-  return m ? decodeURIComponent(m[1]) : null;
-}
-
-/** Essaie de lire le cookie 'session' (compat req.cookies et header brut) */
-function readSessionToken(req) {
-  // Si un parseur de cookies est présent (rare sur Vercel Node pur)
-  if (req.cookies?.session) return req.cookies.session;
-  // Fallback : parser l'en-tête Cookie à la main
-  return getCookie("session", req.headers.cookie || "");
-}
-
-/** Charge l'utilisateur courant depuis la DB */
-async function fetchUserById(id) {
-  // 1) Essaye avec la colonne "role"
-  try {
-    const { rows } = await sql`
-      SELECT id, email, first_name, last_name, avatar_url, role
-      FROM users
-      WHERE id = ${id}
-      LIMIT 1
-    `;
-    return rows[0] || null;
-  } catch (err) {
-    // 2) Si la colonne n'existe pas encore => fallback sans "role"
-    // code SQLSTATE '42703' = undefined_column
-    if (err?.code === "42703") {
-      const { rows } = await sql`
-        SELECT id, email, first_name, last_name, avatar_url
-        FROM users
-        WHERE id = ${id}
-        LIMIT 1
-      `;
-      if (!rows[0]) return null;
-      return { ...rows[0], role: "user" }; // défaut
-    }
-    throw err;
-  }
-}
+import { getUserFromRequest } from '../../lib/auth.js';
 
 export default async function handler(req, res) {
-  if (req.method !== "GET") {
-    res.setHeader("Allow", "GET");
-    return res.status(405).json({ message: "Method Not Allowed" });
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ message: 'Method Not Allowed' });
   }
 
   try {
-    // 1) Lire et vérifier le JWT depuis le cookie
-    const token = readSessionToken(req);
-    if (!token) return res.status(401).json({ authenticated: false });
-
-    const secret = process.env.SESSION_SECRET;
-    const payload = jwt.verify(token, secret); // lève si invalide
-
-    // 2) Charger l'utilisateur depuis la DB
-    const user = await fetchUserById(payload.sub);
+    const user = await getUserFromRequest(req);
     if (!user) return res.status(401).json({ authenticated: false });
 
-    // 3) Réponse standardisée
     return res.status(200).json({
       authenticated: true,
       user: {
@@ -71,11 +18,11 @@ export default async function handler(req, res) {
         first_name: user.first_name,
         last_name: user.last_name,
         avatar_url: user.avatar_url,
-        role: user.role ?? "user",
+        role: user.role ?? 'user',
       },
     });
   } catch (e) {
-    console.error("[AUTH/USER]", e);
+    console.error('[AUTH/USER]', e);
     return res.status(401).json({ authenticated: false });
   }
 }

--- a/api/callback.js
+++ b/api/callback.js
@@ -1,5 +1,6 @@
 // /api/callback.js
 import jwt from "jsonwebtoken";
+import { sql } from "@vercel/postgres";
 
 export default async function handler(req, res) {
   if (req.method !== "GET") {
@@ -43,12 +44,33 @@ export default async function handler(req, res) {
     const email = profile.email;
     if (!email) return res.status(400).json({ message: "Google profile has no email" });
 
-    // Si tu n'utilises pas encore la DB, on peut mettre l'email comme sub
-    const payload = { sub: email, email, provider: "google" };
+    // Upsert de l'utilisateur dans la base
+    const firstName = profile.given_name || null;
+    const lastName = profile.family_name || null;
+    const avatarUrl = profile.picture || null;
+
+    const { rows } = await sql`
+      INSERT INTO users (email, first_name, last_name, avatar_url)
+      VALUES (${email}, ${firstName}, ${lastName}, ${avatarUrl})
+      ON CONFLICT (email) DO UPDATE SET
+        first_name = EXCLUDED.first_name,
+        last_name = EXCLUDED.last_name,
+        avatar_url = EXCLUDED.avatar_url
+      RETURNING id
+    `;
+    const user = rows[0];
+
+    if (!user) return res.status(500).json({ step: "db", message: "User upsert failed" });
+
+    // Promotion automatique en admin si nécessaire
+    if (process.env.ADMIN_EMAIL && process.env.ADMIN_EMAIL === email) {
+      await sql`UPDATE users SET role = 'admin' WHERE email = ${email}`;
+    }
 
     const secret = process.env.SESSION_SECRET;
     if (!secret) return res.status(500).json({ step: "jwt", message: "SESSION_SECRET missing" });
 
+    const payload = { sub: user.id, email, provider: "google" };
     const sessionToken = jwt.sign(payload, secret, { expiresIn: "7d" });
 
     res.setHeader(

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,42 @@
+import jwt from 'jsonwebtoken';
+import { sql } from '@vercel/postgres';
+
+function getCookie(name, cookieHeader = '') {
+  const m = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+function readSessionToken(req) {
+  if (req.cookies?.session) return req.cookies.session;
+  return getCookie('session', req.headers.cookie || '');
+}
+
+export async function getUserFromRequest(req) {
+  const token = readSessionToken(req);
+  if (!token) return null;
+  try {
+    const payload = jwt.verify(token, process.env.SESSION_SECRET);
+    const { rows } = await sql`
+      SELECT id, email, first_name, last_name, avatar_url, role
+      FROM users
+      WHERE id = ${payload.sub}
+      LIMIT 1
+    `;
+    return rows[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function requireAdmin(req, res) {
+  const user = await getUserFromRequest(req);
+  if (!user) {
+    res.status(401).json({ message: 'Auth required' });
+    return null;
+  }
+  if (user.role !== 'admin') {
+    res.status(403).json({ message: 'Admins only' });
+    return null;
+  }
+  return user;
+}


### PR DESCRIPTION
## Summary
- centralize session parsing and admin role checks
- expose user role in auth endpoint
- add admin-only stats API as example
- upsert Google login into database and sign session with user id

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: client/src/pages/admin/dashboard.tsx: 'o' and 'p' are of type 'unknown')*

------
https://chatgpt.com/codex/tasks/task_b_68a098b2b76c8329b2c3964aab1a93fd