### PR TITLE
Use DATABASE_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ npm install
 Create a `.env` file in the root directory with the following variables:
 
 ```env
-POSTGRES_URL=postgres://username:password@localhost:5432/tunisianchic
+DATABASE_URL=postgres://username:password@localhost:5432/tunisianchic
 STRIPE_SECRET_KEY=your_stripe_secret_key
 SESSION_SECRET=changeme
 GOOGLE_CLIENT_ID=your-google-client-id
@@ -133,7 +133,7 @@ The Express server automatically listens on the port provided via `PORT` and ser
 ### Deploying on Render
 
 
-The included `render.yaml` provisions a free PostgreSQL database and configures the service to run `npm install && npm run build` during the build phase and `npm start` at runtime. Static assets are served from the prebuilt `dist/public` directory. If `POSTGRES_URL` is not set, the server will still boot but only serve the static frontend; API routes remain disabled.
+The included `render.yaml` provisions a free PostgreSQL database and configures the service to run `npm install && npm run build` during the build phase and `npm start` at runtime. Static assets are served from the prebuilt `dist/public` directory. If `DATABASE_URL` is not set, the server will still boot but only serve the static frontend; API routes remain disabled.
 
 
 ## API Endpoints

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -24,7 +24,7 @@ export default async function handler(req, res) {
   }
 
   // Early return if database is not configured
-  if (!process.env.POSTGRES_URL) {
+  if (!process.env.DATABASE_URL) {
     res.status(503).json({ message: 'Database not configured' });
     return;
   }

--- a/api/auth/register.js
+++ b/api/auth/register.js
@@ -24,7 +24,7 @@ export default async function handler(req, res) {
   }
 
   // Early return if database is not configured
-  if (!process.env.POSTGRES_URL) {
+  if (!process.env.DATABASE_URL) {
     res.status(503).json({ message: 'Database not configured' });
     return;
   }

--- a/api/categories.js
+++ b/api/categories.js
@@ -10,7 +10,7 @@ export default async function handler(req, res) {
     return;
   }
 
-  if (!process.env.POSTGRES_URL) {
+  if (!process.env.DATABASE_URL) {
     return res.status(200).json([{ id: 1, name: 'Test' }]);
   }
 
@@ -26,7 +26,7 @@ export default async function handler(req, res) {
     res.status(500).json({
       message: 'Database error',
       error: error.message,
-      hasDatabase: !!process.env.POSTGRES_URL
+      hasDatabase: !!process.env.DATABASE_URL
     });
   }
 }

--- a/api/products.js
+++ b/api/products.js
@@ -10,7 +10,7 @@ export default async function handler(req, res) {
     return;
   }
 
-  if (!process.env.POSTGRES_URL) {
+  if (!process.env.DATABASE_URL) {
     return res.status(200).json({ items: [] });
   }
 
@@ -38,7 +38,7 @@ export default async function handler(req, res) {
     res.status(500).json({
       message: 'Database error',
       error: error.message,
-      hasDatabase: !!process.env.POSTGRES_URL
+      hasDatabase: !!process.env.DATABASE_URL
     });
   }
 }

--- a/api/serverless-handler.js
+++ b/api/serverless-handler.js
@@ -7,8 +7,8 @@ let isInitialized = false;
 // Initialize the app once
 const initializeApp = async () => {
   if (!isInitialized) {
-    // Only register routes if we have POSTGRES_URL
-    if (process.env.POSTGRES_URL) {
+    // Only register routes if we have DATABASE_URL
+    if (process.env.DATABASE_URL) {
       try {
         const { registerRoutes } = await import('../dist/server/routes.js');
         await registerRoutes(app);
@@ -18,7 +18,7 @@ const initializeApp = async () => {
         // Don't throw, just log - let the app start without routes
       }
     } else {
-      console.warn('POSTGRES_URL not set, skipping route registration');
+      console.warn('DATABASE_URL not set, skipping route registration');
     }
     isInitialized = true;
   }

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -6,6 +6,6 @@ export default {
   out: './drizzle',               // dossier où écrire les migrations
   dialect: 'postgresql',          // (nouveau drizzle-kit) ou driver: 'pg' pour anciennes versions
   dbCredentials: {
-    url: process.env.POSTGRES_URL!, // exemple: postgres://user:pass@localhost:5432/ma_base
+    url: process.env.DATABASE_URL!, // exemple: postgres://user:pass@localhost:5432/ma_base
   },
 } satisfies Config;

--- a/render.yaml
+++ b/render.yaml
@@ -14,5 +14,5 @@ services:
       - key: NODE_VERSION
         value: 22.16.0
 
-      - key: POSTGRES_URL
+      - key: DATABASE_URL
         fromDatabase: elegance-db

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -17,7 +17,7 @@ const REDIRECT_URI = `${PUBLIC_BASE_URL}${CALLBACK_PATH}`;
 export async function setupAuth(app: Express): Promise<void> {
   const {
     SESSION_SECRET,
-    POSTGRES_URL,
+    DATABASE_URL,
     GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET,
     NODE_ENV,
@@ -41,7 +41,7 @@ export async function setupAuth(app: Express): Promise<void> {
   const sessionTtl = 7 * 24 * 60 * 60 * 1000; // 7 jours
   const PgStore = connectPg(session);
   const sessionStore = new PgStore({
-    pool: createPool({ connectionString: POSTGRES_URL }),
+    pool: createPool({ connectionString: DATABASE_URL }),
     createTableIfMissing: false, // mets true si la table "sessions" n'existe pas
     ttl: sessionTtl / 1000, // connect-pg-simple attend des secondes si set via "ttl"
     tableName: "sessions",

--- a/server/db.ts
+++ b/server/db.ts
@@ -4,8 +4,8 @@ import { drizzle } from "drizzle-orm/vercel-postgres";
 import * as schema from "@shared/schema";
 import "dotenv/config";
 
-if (!process.env.POSTGRES_URL) {
-  throw new Error("POSTGRES_URL must be set");
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL must be set");
 }
 
 export const db = drizzle(sql, { schema });

--- a/server/index.ts
+++ b/server/index.ts
@@ -60,12 +60,12 @@ app.get("/api/health", (_req: Request, res: Response) => {
 });
 
 // Routes will be registered in serverless handler or local dev
-if (process.env.NODE_ENV === "development" && process.env.POSTGRES_URL) {
+if (process.env.NODE_ENV === "development" && process.env.DATABASE_URL) {
   const { registerRoutes } = await import("./routes");
   await registerRoutes(app);
   log("Routes registered for development");
-} else if (!process.env.POSTGRES_URL) {
-  log("POSTGRES_URL not set, API routes disabled", "warn");
+} else if (!process.env.DATABASE_URL) {
+  log("DATABASE_URL not set, API routes disabled", "warn");
 } else {
   log("Production mode - routes will be registered by serverless handler");
 }


### PR DESCRIPTION
## Summary
- replace POSTGRES_URL references with DATABASE_URL across server, API, config and docs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: client/src/pages/admin/dashboard.tsx(356,45): error TS18046: 'o' is of type 'unknown'.)*

------
https://chatgpt.com/codex/tasks/task_b_68a22ce29dc48329ba2163f501ef9319