### PR TITLE
feat: standardize DATABASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+DATABASE_URL=postgres://username:password@localhost:5432/tunisianchic
+STRIPE_SECRET_KEY=your_stripe_secret_key
+SESSION_SECRET=changeme
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+PUBLIC_BASE_URL=http://localhost:5000
+GOOGLE_CALLBACK_PATH=/api/callback
+# SMTP configuration for contact form
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_smtp_user
+SMTP_PASS=your_smtp_password
+CONTACT_RECIPIENT=contact@example.com
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ server/public
 vite.config.ts.*
 *.tar.gz
 .env
-.env.example

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm install
 
 3. Set up environment variables
 
-Create a `.env` file in the root directory with the following variables:
+Create a `.env` file in the root directory (you can start from `.env.example`) with the following variables:
 
 ```env
 DATABASE_URL=postgres://username:password@localhost:5432/tunisianchic
@@ -106,6 +106,8 @@ SMTP_USER=your_smtp_user
 SMTP_PASS=your_smtp_password
 CONTACT_RECIPIENT=contact@example.com
 ```
+
+For deployments on Vercel, configure the `DATABASE_URL` environment variable in your project settings.
 
 4. Run migrations
 

--- a/api/categories.js
+++ b/api/categories.js
@@ -1,4 +1,10 @@
-import { sql } from '@vercel/postgres';
+import { createPool } from '@vercel/postgres';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  throw new Error('DATABASE_URL is not set');
+}
+const db = createPool({ connectionString: DATABASE_URL });
 
 export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -10,13 +16,9 @@ export default async function handler(req, res) {
     return;
   }
 
-  if (!process.env.DATABASE_URL) {
-    return res.status(200).json([{ id: 1, name: 'Test' }]);
-  }
-
   try {
     if (req.method === 'GET') {
-      const { rows } = await sql`SELECT * FROM categories ORDER BY name`;
+      const { rows } = await db.sql`SELECT * FROM categories ORDER BY name`;
       res.status(200).json(rows);
     } else {
       res.status(405).json({ message: 'Method not allowed' });
@@ -26,7 +28,7 @@ export default async function handler(req, res) {
     res.status(500).json({
       message: 'Database error',
       error: error.message,
-      hasDatabase: !!process.env.DATABASE_URL
+      hasDatabase: !!DATABASE_URL
     });
   }
 }

--- a/api/products.js
+++ b/api/products.js
@@ -1,4 +1,10 @@
-import { sql } from '@vercel/postgres';
+import { createPool } from '@vercel/postgres';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  throw new Error('DATABASE_URL is not set');
+}
+const db = createPool({ connectionString: DATABASE_URL });
 
 export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -10,21 +16,17 @@ export default async function handler(req, res) {
     return;
   }
 
-  if (!process.env.DATABASE_URL) {
-    return res.status(200).json({ items: [] });
-  }
-
   try {
     if (req.method === 'GET') {
       const { isFeatured, limit } = req.query;
       const limitValue = Number.parseInt(limit, 10) || 8;
 
-      const products = await sql`
+      const products = await db.sql`
         SELECT p.*, c.name as category_name
         FROM products p
         LEFT JOIN categories c ON p.category_id = c.id
         WHERE p.is_active = true
-        ${isFeatured === 'true' ? sql`AND p.is_featured = true` : sql``}
+        ${isFeatured === 'true' ? db.sql`AND p.is_featured = true` : db.sql``}
         ORDER BY p.created_at DESC
         LIMIT ${limitValue}
       `;
@@ -38,7 +40,7 @@ export default async function handler(req, res) {
     res.status(500).json({
       message: 'Database error',
       error: error.message,
-      hasDatabase: !!process.env.DATABASE_URL
+      hasDatabase: !!DATABASE_URL
     });
   }
 }

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,6 +1,10 @@
 import 'dotenv/config';
 import type { Config } from 'drizzle-kit';
 
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL must be set');
+}
+
 export default {
   schema: './shared/schema.ts',   // <-- chemin VERS ton @shared/schema
   out: './drizzle',               // dossier où écrire les migrations

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,12 +1,14 @@
 // server/db.ts
-import { sql } from "@vercel/postgres";
+import { createPool } from "@vercel/postgres";
 import { drizzle } from "drizzle-orm/vercel-postgres";
 import * as schema from "@shared/schema";
 import "dotenv/config";
 
-if (!process.env.DATABASE_URL) {
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
   throw new Error("DATABASE_URL must be set");
 }
+const pool = createPool({ connectionString: DATABASE_URL });
 
-export const db = drizzle(sql, { schema });
+export const db = drizzle(pool, { schema });
 export default db;


### PR DESCRIPTION
## Summary
- standardize database env var to `DATABASE_URL`
- wire @vercel/postgres pools with explicit `connectionString`
- document new `DATABASE_URL` usage and add `.env.example`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS18046 in dashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a252d31134832990f920602893f745