### PR TITLE
fix: allow google auth to work on http dev

### DIFF
--- a/api/callback.js
+++ b/api/callback.js
@@ -51,10 +51,17 @@ export default async function handler(req, res) {
 
     const sessionToken = jwt.sign(payload, secret, { expiresIn: "7d" });
 
-    res.setHeader(
-      "Set-Cookie",
-      `session=${sessionToken}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${7 * 24 * 60 * 60}`
-    );
+    const isProd = process.env.NODE_ENV === "production";
+    const cookieParts = [
+      `session=${sessionToken}`,
+      "Path=/",
+      "HttpOnly",
+      isProd ? "Secure" : undefined,
+      "SameSite=Lax",
+      `Max-Age=${7 * 24 * 60 * 60}`,
+    ].filter(Boolean);
+
+    res.setHeader("Set-Cookie", cookieParts.join("; "));
 
     return res.redirect(302, "/");
   } catch (e) {


### PR DESCRIPTION
## Summary
- set secure cookie only in production
- handle products endpoint when database is missing and enable credential-aware CORS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_68a257caf56883298132af3b77a972c3