### PR TITLE
feat: add PowerShell API test scripts

### DIFF
--- a/scripts/api-tests/README.md
+++ b/scripts/api-tests/README.md
@@ -1,0 +1,38 @@
+# Tests API
+
+Ce dossier contient des scripts PowerShell pour tester les routes CRUD de l'API.
+
+## Configuration
+
+- Modifier l'URL de base dans chaque script si besoin :
+  ```powershell
+  $BASE_URL = "https://elegance-ten.vercel.app"
+  ```
+- Pour les routes nécessitant une session, coller vos cookies dans la variable `$COOKIE` :
+  ```powershell
+  $COOKIE = "sid=...; other=..."
+  ```
+
+## Exécution
+
+Depuis PowerShell :
+
+```powershell
+cd scripts\api-tests
+# exemple
+.\products_list.ps1
+```
+
+Pour lancer les tests de base :
+
+```powershell
+.\run_all.ps1
+```
+
+## Codes HTTP courants
+
+- **401** : non connecté → ajouter `$COOKIE`.
+- **404/405** : problème de routing Vercel → vérifier catch-all `/api/[...all]` et `vercel.json`.
+- **500** : erreur serveur (DB/validation) → vérifier `DATABASE_URL` (host `-pooler` + `?sslmode=require`) et les logs Vercel.
+
+> Si `categories_delete.ps1 -Id 1` échoue, utiliser un identifiant de catégorie existant.

--- a/scripts/api-tests/categories_create.ps1
+++ b/scripts/api-tests/categories_create.ps1
@@ -1,0 +1,17 @@
+param([string]$Name)
+
+$BASE_URL = "https://elegance-ten.vercel.app"
+$COOKIE   = ""
+
+$headers = @{ "Content-Type"="application/json" }
+if ($COOKIE) { $headers["Cookie"] = $COOKIE }
+
+$body = @{ name=$Name } | ConvertTo-Json
+try {
+  $r = Invoke-WebRequest -Uri "$BASE_URL/api/categories" -Headers $headers -Method POST -Body $body -ErrorAction Stop
+  Write-Output $r.Content
+} catch {
+  $res = $_.Exception.Response
+  Write-Host "HTTP $($res.StatusCode.value__)"
+  (New-Object IO.StreamReader($res.GetResponseStream())).ReadToEnd()
+}

--- a/scripts/api-tests/categories_delete.ps1
+++ b/scripts/api-tests/categories_delete.ps1
@@ -1,0 +1,17 @@
+param([int]$Id)
+
+$BASE_URL = "https://elegance-ten.vercel.app"
+$COOKIE   = ""
+
+$headers = @{ "Content-Type"="application/json" }
+if ($COOKIE) { $headers["Cookie"] = $COOKIE }
+
+try {
+  $r = Invoke-WebRequest -Uri "$BASE_URL/api/categories/$Id" -Headers $headers -Method DELETE -ErrorAction Stop
+  Write-Host "HTTP $($r.StatusCode)"
+  Write-Output $r.Content
+} catch {
+  $res = $_.Exception.Response
+  Write-Host "HTTP $($res.StatusCode.value__)"
+  (New-Object IO.StreamReader($res.GetResponseStream())).ReadToEnd()
+}

--- a/scripts/api-tests/categories_list.ps1
+++ b/scripts/api-tests/categories_list.ps1
@@ -1,0 +1,14 @@
+$BASE_URL = "https://elegance-ten.vercel.app"
+$COOKIE   = ""
+
+$headers = @{ "Content-Type"="application/json" }
+if ($COOKIE) { $headers["Cookie"] = $COOKIE }
+
+try {
+  $r = Invoke-WebRequest -Uri "$BASE_URL/api/categories" -Headers $headers -Method GET -ErrorAction Stop
+  Write-Output $r.Content
+} catch {
+  $res = $_.Exception.Response
+  Write-Host "HTTP $($res.StatusCode.value__)"
+  (New-Object IO.StreamReader($res.GetResponseStream())).ReadToEnd()
+}

--- a/scripts/api-tests/products_create.ps1
+++ b/scripts/api-tests/products_create.ps1
@@ -1,0 +1,17 @@
+param([string]$Name="X", [decimal]$Price=10, [int]$CategoryId=1)
+
+$BASE_URL = "https://elegance-ten.vercel.app"
+$COOKIE   = ""
+
+$headers = @{ "Content-Type"="application/json" }
+if ($COOKIE) { $headers["Cookie"] = $COOKIE }
+
+$body = @{ name=$Name; price=$Price; categoryId=$CategoryId } | ConvertTo-Json
+try {
+  $r = Invoke-WebRequest -Uri "$BASE_URL/api/products" -Headers $headers -Method POST -Body $body -ErrorAction Stop
+  Write-Output $r.Content
+} catch {
+  $res = $_.Exception.Response
+  Write-Host "HTTP $($res.StatusCode.value__)"
+  (New-Object IO.StreamReader($res.GetResponseStream())).ReadToEnd()
+}

--- a/scripts/api-tests/products_delete.ps1
+++ b/scripts/api-tests/products_delete.ps1
@@ -1,0 +1,17 @@
+param([int]$Id)
+
+$BASE_URL = "https://elegance-ten.vercel.app"
+$COOKIE   = ""
+
+$headers = @{ "Content-Type"="application/json" }
+if ($COOKIE) { $headers["Cookie"] = $COOKIE }
+
+try {
+  $r = Invoke-WebRequest -Uri "$BASE_URL/api/products/$Id" -Headers $headers -Method DELETE -ErrorAction Stop
+  Write-Host "HTTP $($r.StatusCode)"
+  Write-Output $r.Content
+} catch {
+  $res = $_.Exception.Response
+  Write-Host "HTTP $($res.StatusCode.value__)"
+  (New-Object IO.StreamReader($res.GetResponseStream())).ReadToEnd()
+}

--- a/scripts/api-tests/products_list.ps1
+++ b/scripts/api-tests/products_list.ps1
@@ -1,0 +1,14 @@
+$BASE_URL = "https://elegance-ten.vercel.app"
+$COOKIE   = ""  # ex: "sid=...; other=..."
+
+$headers = @{ "Content-Type"="application/json" }
+if ($COOKIE) { $headers["Cookie"] = $COOKIE }
+
+try {
+  $r = Invoke-WebRequest -Uri "$BASE_URL/api/products" -Headers $headers -Method GET -ErrorAction Stop
+  Write-Output $r.Content
+} catch {
+  $res = $_.Exception.Response
+  Write-Host "HTTP $($res.StatusCode.value__)"
+  (New-Object IO.StreamReader($res.GetResponseStream())).ReadToEnd()
+}

--- a/scripts/api-tests/products_update.ps1
+++ b/scripts/api-tests/products_update.ps1
@@ -1,0 +1,17 @@
+param([int]$Id, [decimal]$Price)
+
+$BASE_URL = "https://elegance-ten.vercel.app"
+$COOKIE   = ""
+
+$headers = @{ "Content-Type"="application/json" }
+if ($COOKIE) { $headers["Cookie"] = $COOKIE }
+
+$body = @{ price=$Price } | ConvertTo-Json
+try {
+  $r = Invoke-WebRequest -Uri "$BASE_URL/api/products/$Id" -Headers $headers -Method PUT -Body $body -ErrorAction Stop
+  Write-Output $r.Content
+} catch {
+  $res = $_.Exception.Response
+  Write-Host "HTTP $($res.StatusCode.value__)"
+  (New-Object IO.StreamReader($res.GetResponseStream())).ReadToEnd()
+}

--- a/scripts/api-tests/profile_update.ps1
+++ b/scripts/api-tests/profile_update.ps1
@@ -1,0 +1,21 @@
+param([string]$FirstName, [string]$LastName="", [string]$Phone="", [string]$Address="", [string]$City="", [string]$PostalCode="")
+
+$BASE_URL = "https://elegance-ten.vercel.app"
+$COOKIE   = ""  # nécessaire si l'endpoint exige une session (401 sinon)
+
+$headers = @{ "Content-Type"="application/json" }
+if ($COOKIE) { $headers["Cookie"] = $COOKIE }
+
+$body = @{
+  firstName = $FirstName; lastName = $LastName; phone = $Phone
+  address = $Address; city = $City; postalCode = $PostalCode
+} | ConvertTo-Json
+
+try {
+  $r = Invoke-WebRequest -Uri "$BASE_URL/api/auth/profile" -Headers $headers -Method PATCH -Body $body -ErrorAction Stop
+  Write-Output $r.Content
+} catch {
+  $res = $_.Exception.Response
+  Write-Host "HTTP $($res.StatusCode.value__)"
+  (New-Object IO.StreamReader($res.GetResponseStream())).ReadToEnd()
+}

--- a/scripts/api-tests/run_all.ps1
+++ b/scripts/api-tests/run_all.ps1
@@ -1,0 +1,17 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+cd $here
+
+Write-Host "=== Products: list ===" -ForegroundColor Cyan
+.\products_list.ps1
+
+Write-Host "`n=== Categories: list ===" -ForegroundColor Cyan
+.\categories_list.ps1
+
+Write-Host "`n=== Categories: create (NewCat) ===" -ForegroundColor Cyan
+.\categories_create.ps1 -Name "NewCat"
+
+Write-Host "`n=== Categories: delete (id=1 - exemple) ===" -ForegroundColor Cyan
+.\categories_delete.ps1 -Id 1


### PR DESCRIPTION
## Summary
- add PowerShell scripts for product and category CRUD API testing
- include profile update script, runner script, and usage docs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TS18046 etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68a30ce91f548329a1b26bc67f6e4fcb