### PR TITLE
Fix serverless route loading by using absolute paths and bundling routes

### DIFF
--- a/api/[...all].ts
+++ b/api/[...all].ts
@@ -1,4 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 let cachedApp: any;
 async function loadApp() {
@@ -6,7 +8,10 @@ async function loadApp() {
   const url = process.env.DATABASE_URL || process.env.POSTGRES_URL;
   if (!url) throw new Error('DATABASE_URL/POSTGRES_URL is missing');
 
-  const mod = await import('../dist/server/index.js');
+  const serverPath = pathToFileURL(
+    join(process.cwd(), 'dist', 'server', 'index.js')
+  ).href;
+  const mod = await import(serverPath);
   const app =
     (typeof mod.default === 'function' ? mod.default : (mod as any).app) ||
     (typeof (mod as any).createApp === 'function' ? (mod as any).createApp() : (mod as any).app);
@@ -16,7 +21,10 @@ async function loadApp() {
   }
 
   try {
-    const routes = await import('../dist/server/routes.js');
+    const routesPath = pathToFileURL(
+      join(process.cwd(), 'dist', 'server', 'routes.js')
+    ).href;
+    const routes = await import(routesPath);
     if (typeof routes.registerRoutes === 'function') {
       await routes.registerRoutes(app);
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "cross-env NODE_ENV=development tsx watch server/index.ts",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build",
-    "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist/server",
+    "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist/server && esbuild server/routes.ts --platform=node --packages=external --bundle --format=esm --outdir=dist/server",
     "start": "cross-env NODE_ENV=production node dist/server/index.js",
     "vercel-build": "npm run build",
     "seed": "tsx server/seed.ts",


### PR DESCRIPTION
## Summary
- ensure serverless handler loads built server and routes using absolute paths
- bundle server routes during build so API can register endpoints

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_b_68a31ad337c8832982762cc684e3e9bf